### PR TITLE
Include symlinked directories in PathsDB

### DIFF
--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -96,7 +96,7 @@ class PathsDb(object):
         }
 
         # get information for each directory
-        for path, dirnames, filenames in os.walk(self.basepath):
+        for path, dirnames, filenames in os.walk(self.basepath, followlinks=True):
             relpath = os.path.relpath(path, self.basepath)
 
             # sort images and sub-albums by name


### PR DESCRIPTION
That would be quite nice for people like me who already have a directory hierachy containing several gigabytes of images, which they would like to use for a gallery without copying them. Plus I would like keep sigals config and output with my web stuff and out of my [git-annex](https://git-annex.branchable.com) repo.
