### PR TITLE
Convert video to temp file to be able to resume later (version 2)

### DIFF
--- a/sigal/video.py
+++ b/sigal/video.py
@@ -120,7 +120,7 @@ def generate_video(source, outname, size, options=None):
     if options is not None:
         cmd += options
     cmd += ['-f','webm'] #force webm because temp file has another extension
-    cmd += resize_opt + [outname]
+    cmd += resize_opt + [tempoutname]
 
     logger.debug('Processing video: %s', ' '.join(cmd))
     try:


### PR DESCRIPTION
When conversion is interrupted or experiences some problems (for example network problems with a network share), python multiprocessing returns an error, but the part of the file that was already converted remains in the directory. When conversion is started again, the video is skipped just because it exists in the destination folder.

Workaround: convert to a temporary file and rename the file after conversion is finished. On restarting the conversion, existing temporary files are removed and the conversion is performed again from the beginning. With this addition you can start the build command again when something had gone wrong in the previous run.
