### PR TITLE
Fix "UnicodeDecodeError: 'ascii' codec ..." on UTF-8 filesystems

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -147,6 +147,9 @@ def serve(path):
 
 
 def main():
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
+    
     parser = ArghParser(description='Simple static gallery generator.')
     parser.add_commands([init, build, serve])
     parser.add_argument('--version', action='version',


### PR DESCRIPTION
When using a filesystem with utf-8 encoding, any non ascii character
(like accented letters) in a folder name will make sigal throw an
exception like:

...
  File "/usr/local/lib/python2.7/dist-
packages/sigal-0.6.0-py2.7.egg/sigal/gallery.py", line 221, in build
    for files in self.process_dir(path):
  File "/usr/local/lib/python2.7/dist-
packages/sigal-0.6.0-py2.7.egg/sigal/gallery.py", line 255, in
process_dir
    for f in self.db[path]['medias']]
  File "/usr/lib/python2.7/posixpath.py", line 80, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 17: ordinal not in range(128)

---

Warning: this solution is ugly and dirty (ahem... just as this Python 2.x's unicode bug)

Solution from:
http://stackoverflow.com/questions/3828723/why-we-need-sys-setdefaultencodingutf-8-in-a-py-script
