### PR TITLE
IOError-handler added to gallery.worker to prevent sigal from dying on invalid images.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ alphabetical order):
 - Christophe-Marie Duquesne
 - Jonas Kaufmann
 - Antoine Pitrou
+- Juha Ruotsalainen
 - Matthias Vogelgesang
 - Vikram Shirgur
 - Yuce Tekol

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -646,3 +646,6 @@ def worker(args):
         return process_file(args)
     except KeyboardInterrupt:
         pass
+    except IOError:
+        logger = logging.getLogger(__name__)
+        logger.warn("File failed: %s"%os.path.sep.join(args[1:3]))


### PR DESCRIPTION
This is related to the issue I filed, https://github.com/saimn/sigal/issues/134, about Sigal dying on invalid image files. E.g. empty ones.

p.s. Sorry about not squashing those commits. I remembered that one only after pushing the first commit.