### PR TITLE
Honor 'use_orig' for videos

### DIFF
--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -179,8 +179,9 @@ class Video(Media):
         base = splitext(filename)[0]
         self.date = None
         self.src_filename = filename
-        self.filename = self.url = base + '.webm'
-        self.dst_path = join(settings['destination'], path, base + '.webm')
+        if not settings['use_orig']:
+            self.filename = self.url = base + '.webm'
+            self.dst_path = join(settings['destination'], path, base + '.webm')
 
 
 class Album(UnicodeMixin):

--- a/sigal/themes/colorbox/templates/index.html
+++ b/sigal/themes/colorbox/templates/index.html
@@ -120,7 +120,7 @@
               <div style='display:none'>
                 <div id="{{ media.filename|replace('.', '')|replace(' ', '') }}">
                   <video controls>
-                  <source src='{{ media.filename }}' type='video/webm' />
+                  <source src='{{ media.filename }}' {% if not settings.use_orig %}type='video/webm'{% endif %}/>
                   </video>
                 </div>
               </div>


### PR DESCRIPTION
When 'use_orig' is True, copy the original video files (or symlink them,
depending if 'orig_link' is True) to the destination, and use them as they are,
without processing.