### PR TITLE
Colorbox improvements

### DIFF
--- a/sigal/themes/colorbox/static/css/style.css
+++ b/sigal/themes/colorbox/static/css/style.css
@@ -48,7 +48,7 @@ header h1 a {
   box-shadow: 0 0 5px #818181;
 }
 
-.album_title {
+.album_title, .media_title {
   display: block;
 }
 

--- a/sigal/themes/colorbox/templates/index.html
+++ b/sigal/themes/colorbox/templates/index.html
@@ -64,6 +64,7 @@
         {% endif %}
           <img src="{{ media.thumbnail }}" alt="{{ media.filename }}"
               title="{{ media_title }}" /></a>
+        <span class="media_title">{{ media.title if media.title else media.filename }}</span>
       </div>
       {% endif %}
       {% if media.type == "video" %}
@@ -79,6 +80,7 @@
             {% if media.big %} data-big="{{ media.big }}"{% endif %}>
             <img src="{{ media.thumbnail }}" alt="{{ media.filename }}"
                 title="{{ media_title }}" /></a>
+        <span class="media_title">{{ media.title if media.title else media.filename }}</span>
         </div>
         <!-- This contains the hidden content for the video -->
         <div style='display:none'>

--- a/sigal/themes/colorbox/templates/index.html
+++ b/sigal/themes/colorbox/templates/index.html
@@ -74,7 +74,7 @@
           {% if 'sigal.plugins.media_page' in settings.plugins %}
           <a href="{{ media.filename }}.html" data-href="#{{ mhash }}"
           {% else %}
-          <a href="#{{ mhash }}" class="gallery" inline='yes' title="{{ media.filename }}"
+          <a href="#{{ mhash }}" class="gallery" inline='yes' title="{{ media.title if media.title else media.filename }}"
           {% endif %}
             {% if media.big %} data-big="{{ media.big }}"{% endif %}>
             <img src="{{ media.thumbnail }}" alt="{{ media.filename }}"


### PR DESCRIPTION
A couple of minor improvements for colorbox theme:
- Show video title instead of video filename when opening a video.
- As it is done for albums, lets write below each media its title.
