### PR TITLE
Honor `use_orig` with videos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ alphabetical order):
 
 - Christophe-Marie Duquesne
 - Jonas Kaufmann
+- Juan A. Suarez Romero
 - Antoine Pitrou
 - Giel van Schijndel
 - Matthias Vogelgesang

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -44,7 +44,7 @@ from .compat import PY2, UnicodeMixin, strxfrm, url_quote, text_type
 from .image import process_image, get_exif_tags, get_exif_data
 from .settings import get_thumb
 from .utils import (Devnull, copy, check_or_create_dir, url_from_path,
-                    read_markdown, cached_property)
+                    read_markdown, cached_property, is_valid_html5_video)
 from .video import process_video
 from .writer import Writer
 
@@ -176,11 +176,12 @@ class Video(Media):
 
     def __init__(self, filename, path, settings):
         super(Video, self).__init__(filename, path, settings)
-        base = splitext(filename)[0]
+        (base, ext) = splitext(filename)
         self.date = None
         self.src_filename = filename
-        self.filename = self.url = base + '.webm'
-        self.dst_path = join(settings['destination'], path, base + '.webm')
+        if not settings['use_orig'] or not is_valid_html5_video(ext):
+            self.filename = self.url = base + '.webm'
+            self.dst_path = join(settings['destination'], path, base + '.webm')
 
 
 class Album(UnicodeMixin):

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -44,7 +44,8 @@ from .compat import PY2, UnicodeMixin, strxfrm, url_quote, text_type
 from .image import process_image, get_exif_tags, get_exif_data
 from .settings import get_thumb
 from .utils import (Devnull, copy, check_or_create_dir, url_from_path,
-                    read_markdown, cached_property, is_valid_html5_video)
+                    read_markdown, cached_property, is_valid_html5_video,
+                    get_mime)
 from .video import process_video
 from .writer import Writer
 
@@ -181,7 +182,10 @@ class Video(Media):
         self.src_filename = filename
         if not settings['use_orig'] or not is_valid_html5_video(ext):
             self.filename = self.url = base + '.webm'
+            self.mime = get_mime('.webm')
             self.dst_path = join(settings['destination'], path, base + '.webm')
+        else:
+            self.mime = get_mime(ext)
 
 
 class Album(UnicodeMixin):

--- a/sigal/themes/colorbox/templates/index.html
+++ b/sigal/themes/colorbox/templates/index.html
@@ -84,7 +84,7 @@
         <div style='display:none'>
           <div id="{{ mhash }}">
             <video controls>
-            <source src='{{ media.filename }}' type='video/webm' />
+            <source src='{{ media.filename }}' type='{{ media.mime }}' />
             </video>
           </div>
         </div>

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -103,6 +103,13 @@ def is_valid_html5_video(ext):
     """Checks if ext is a supported HTML5 video."""
     return ext in ('.mp4', '.webm', '.ogv')
 
+def get_mime(ext):
+    """Returns mime type for extension."""
+    mimes = {'.mp4': 'video/mp4',
+             '.webm': 'video/webm',
+             '.ogv': 'video/ogg'}
+    return mimes[ext]
+
 class cached_property(object):
     """ A property that is only computed once per instance and then replaces
     itself with an ordinary attribute. Deleting the attribute resets the

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -99,6 +99,9 @@ def call_subprocess(cmd):
         stdout = stdout.decode('utf8')
     return p.returncode, stdout, stderr
 
+def is_valid_html5_video(ext):
+    """Checks if ext is a supported HTML5 video."""
+    return ext in ('.mp4', '.webm', '.ogv')
 
 class cached_property(object):
     """ A property that is only computed once per instance and then replaces

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -114,6 +114,7 @@ def test_image(settings, tmpdir):
 
 def test_video(settings, tmpdir):
     settings['destination'] = str(tmpdir)
+    settings['use_orig'] = False
     m = Video('stallman software-freedom-day-low.ogv', 'video', settings)
     file_path = join('video', 'stallman software-freedom-day-low.webm')
     assert str(m) == file_path

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,6 +5,7 @@ from __future__ import division
 import os
 
 from sigal.video import video_size, generate_video
+from sigal.settings import create_settings
 
 CURRENT_DIR = os.path.dirname(__file__)
 TEST_VIDEO = 'stallman software-freedom-day-low.ogv'
@@ -21,7 +22,8 @@ def test_generate_video_fit_height(tmpdir):
 
     base, ext = os.path.splitext(TEST_VIDEO)
     dstfile = str(tmpdir.join(base + '.webm'))
-    generate_video(SRCFILE, dstfile, (50, 100))
+    settings = create_settings(video_size=(50, 100))
+    generate_video(SRCFILE, dstfile, settings)
 
     size_src = video_size(SRCFILE)
     size_dst = video_size(dstfile)
@@ -36,7 +38,8 @@ def test_generate_video_fit_width(tmpdir):
 
     base, ext = os.path.splitext(TEST_VIDEO)
     dstfile = str(tmpdir.join(base + '.webm'))
-    generate_video(SRCFILE, dstfile, (100, 50))
+    settings = create_settings(video_size=(100, 50))
+    generate_video(SRCFILE, dstfile, settings)
 
     size_src = video_size(SRCFILE)
     size_dst = video_size(dstfile)
@@ -51,7 +54,8 @@ def test_generate_video_dont_enlarge(tmpdir):
 
     base, ext = os.path.splitext(TEST_VIDEO)
     dstfile = str(tmpdir.join(base + '.webm'))
-    generate_video(SRCFILE, dstfile, (1000, 1000))
+    settings = create_settings(video_size=(1000, 1000))
+    generate_video(SRCFILE, dstfile, settings)
 
     size_src = video_size(SRCFILE)
     size_dst = video_size(dstfile)


### PR DESCRIPTION
So far `use_orig` is totally ignored for the case of videos.

But giving that lot of times we have a big amount of videos that we don't want to process because it is expensive, or they are already web-friendly.

This set of commits makes `use_orig` to be respected in case of videos.

I was doubting between following this, or adding a new `video_use_orig` (and `video_orig_link`). But at the end I decided to use the same property for both cases.
