### PR TITLE
Enable autoescape in jinja templates

### DIFF
--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -24,6 +24,7 @@ import codecs
 import os
 import shutil
 from markdown import Markdown
+from markupsafe import Markup
 from subprocess import Popen, PIPE
 
 from . import compat
@@ -80,7 +81,8 @@ def read_markdown(filename):
     md = Markdown(extensions=['markdown.extensions.meta',
                               'markdown.extensions.tables'],
                   output_format='html5')
-    output = {'description': md.convert(text)}
+    # Mark HTML with Markup to prevent jinja2 autoescaping
+    output = {'description': Markup(md.convert(text))}
 
     try:
         meta = md.Meta.copy()

--- a/sigal/writer.py
+++ b/sigal/writer.py
@@ -65,7 +65,7 @@ class Writer(object):
                                                        'templates'))
 
         # setup jinja env
-        env_options = {'trim_blocks': True}
+        env_options = {'trim_blocks': True, 'autoescape': True}
         try:
             if tuple(int(x) for x in jinja2.__version__.split('.')) >= (2, 7):
                 env_options['lstrip_blocks'] = True


### PR DESCRIPTION
Special HTML characters in album and media metatdata were not being escaped in the generated HTML pages. So if a album title contained a ``<``, for example, there was trouble.

This pull request turns on jinja2’s autoescape feature, which solves the problem.
