### PR TITLE
Empty ISO speed ratings

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -270,7 +270,7 @@ def get_exif_tags(data):
         else:
             logger.info('Unknown format for ExposureTime: %r', exptime)
 
-    if 'ISOSpeedRatings' in data:
+    if 'ISOSpeedRatings' in data and data['ISOSpeedRatings']:
         if isinstance(data['ISOSpeedRatings'], tuple):
             # Pillow == 3.0
             simple['iso'] = data['ISOSpeedRatings'][0]

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -137,6 +137,20 @@ def test_get_exif_tags():
     assert 'gps' not in simple
 
 
+def test_iso_speed_ratings():
+    data = {'ISOSpeedRatings': ()}
+    simple = get_exif_tags(data)
+    assert 'iso' not in simple
+
+    data = {'ISOSpeedRatings': None}
+    simple = get_exif_tags(data)
+    assert 'iso' not in simple
+
+    data = {'ISOSpeedRatings': 125}
+    simple = get_exif_tags(data)
+    assert 'iso' in simple
+
+
 def test_null_exposure_time():
     data = {'ExposureTime': (0, 0)}
     simple = get_exif_tags(data)


### PR DESCRIPTION
I found a couple of images where the ISOSpeedRatings value is an empty tuple. This makes sigal sad. Added a test and also fixed the issue so the test passes now.

PS CONTRIBUTING.rst mentions "squash" commits, since github now supports squashing pull requests, is this still necessary? https://github.com/blog/2141-squash-your-commits