### PR TITLE
Add 'title' command.

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -223,3 +223,23 @@ def serve(destination, port, config):
         httpd.serve_forever()
     except KeyboardInterrupt:
         print('\nAll done!')
+
+@main.command()
+@argument('image')
+@argument('title')
+@option('-f', '--force', default=False, is_flag=True,
+        help='Overwrite existing .md file')
+def title(image, title, force=False):
+    "Write image title to corresponding .md file"
+
+    if not os.path.exists(image):
+        sys.stderr.write("The image {} does not exist.\n".format(image))
+        sys.exit(1)
+    descfile = os.path.splitext(image)[0] + '.md'
+    if os.path.exists(descfile) and not force:
+        sys.stderr.write("Description file for {} already exists. "
+                         "Use --force to overwrite it.\n".format(image))
+        sys.exit(2)
+
+    with open(descfile, "w") as fp:
+        fp.write("Title: {}\n".format(title))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from sigal import init
 from sigal import serve
+from sigal import set_meta
 
 
 def test_init(tmpdir):
@@ -32,3 +33,32 @@ def test_serve(tmpdir):
 
     result = runner.invoke(serve, ['-c', config_file])
     assert result.exit_code == 1
+
+def test_set_meta(tmpdir):
+
+    testdir = tmpdir.mkdir("test")
+
+    testfile = tmpdir.join("test.jpg")
+    testfile.write("")
+
+    runner = CliRunner()
+    result = runner.invoke(set_meta, [str(testdir), "title", "testing"])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("1 metadata key(s) written to")
+    assert os.path.isfile(str(testdir.join("index.md")))
+    assert testdir.join("index.md").read() == "Title: testing\n"
+
+    # Run again, should give file exists error
+    result = runner.invoke(set_meta, [str(testdir), "title", "testing"])
+    assert result.exit_code == 2
+
+    result = runner.invoke(set_meta, [str(testdir.join("non-existant.jpg")), "title", "testing"])
+    assert result.exit_code == 1
+
+    result = runner.invoke(set_meta, [str(testfile), "title", "testing"])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("1 metadata key(s) written to")
+    assert os.path.isfile(str(tmpdir.join("test.md")))
+    assert tmpdir.join("test.md").read() == "Title: testing\n"


### PR DESCRIPTION
I found myself wanting a quick way to add simple titles to lots of images. Rather than writing a separate script I thought that just adding a new command to sigal itself might be easier. Do you think this is worth including in upstream sigal? In that case I can add test cases and documentation for it, but wanted to see if you'd want to take it at all first...