### PR TITLE
Fix background-image url for default-skin.svg

### DIFF
--- a/sigal/themes/photoswipe/static/default-skin/default-skin.css
+++ b/sigal/themes/photoswipe/static/default-skin/default-skin.css
@@ -62,7 +62,7 @@
   .pswp--svg .pswp__button,
   .pswp--svg .pswp__button--arrow--left:before,
   .pswp--svg .pswp__button--arrow--right:before {
-    background-image: url(default-skin.svg); }
+    background-image: url(default-skin/default-skin.svg); }
   .pswp--svg .pswp__button--arrow--left,
   .pswp--svg .pswp__button--arrow--right {
     background: none; } }


### PR DESCRIPTION
PhotoSwipe icons for sharing and closing are not shown on my iPhone because the background-image url for default-skin.svg is not correct.

![img_5773](https://cloud.githubusercontent.com/assets/20834291/17399056/5aa9a1aa-5a40-11e6-82d6-40495f91efd6.PNG)
