### PR TITLE
Fix theme HTML title tag contents

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ alphabetical order):
 - François D. (@franek)
 - Giel van Schijndel
 - Jamie Starke
+- Janne Cederberg (@jannecederberg)
 - @jdn06
 - Jeff Dairiki
 - Jonas Kaufmann

--- a/sigal/themes/colorbox/templates/base.html
+++ b/sigal/themes/colorbox/templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{{ album.title }}</title>
+    <title>{{ index_title }}</title>
     <meta name="description" content="">
     <meta name="author" content="{{ album.author }}">
     <meta name="viewport" content="width=device-width">

--- a/sigal/themes/galleria/templates/index.html
+++ b/sigal/themes/galleria/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{{ album.title|striptags }}</title>
+    <title>{{ index_title|striptags }}</title>
     <meta name="description" content="">
     <meta name="author" content="{{ album.author }}">
     <meta name="viewport" content="width=device-width">

--- a/sigal/themes/photoswipe/templates/index.html
+++ b/sigal/themes/photoswipe/templates/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{{ album.title }}</title>
+    <title>{{ index_title }}</title>
     <meta name="description" content="">
     <meta name="author" content="{{ album.author }}">
     <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
Regardless of whether or not the `title` variable is defined
in <kbd>sigal.conf.py</kbd>, the themes show the `source` directory
name in the HTML title tag. This commit fixes that.