### PR TITLE
add a progress bar for writing index files

### DIFF
--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -660,12 +660,15 @@ class Gallery(object):
 
         if failed_files:
             self.remove_files(failed_files)
-        print('')
 
         if self.settings['write_html']:
             writer = Writer(self.settings, index_title=self.title)
-            for album in self.albums.values():
-                writer.write(album)
+            with progressbar(self.albums.values(), label="Writing indices",
+                             item_show_func=log_func, show_eta=False,
+                             file=self.progressbar_target) as albums:
+                for album in albums:
+                    writer.write(album)
+        print('')
 
         signals.gallery_build.send(self)
 


### PR DESCRIPTION
This adds another progress bar. It details the progress of writing the actual `index.html`s. For large galleries (20k images in my case) this can take quite some time (30s) in my case. Without a progressbar it looks like sigal has hung up.