### PR TITLE
Set html lang attribute based upon locale

### DIFF
--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -47,6 +47,7 @@ _DEFAULT_CONFIG = {
     'index_in_url': False,
     'jpg_options': {'quality': 85, 'optimize': True, 'progressive': True},
     'keep_orig': False,
+    'html_language': 'en',
     'leaflet_provider': 'OpenStreetMap.Mapnik',
     'links': '',
     'locale': '',

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -193,6 +193,9 @@ ignore_files = []
 # Specify a different locale. If set to '', the default locale is used.
 # locale = ''
 
+# Define language used on main <html> tag in templates
+# html_language = 'en'
+
 # List of files to copy from the source directory to the destination.
 # A symbolic link is used if ``orig_link`` is set to True (see above).
 # files_to_copy = (('extra/robots.txt', 'robots.txt'),

--- a/sigal/themes/colorbox/templates/base.html
+++ b/sigal/themes/colorbox/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ settings.html_language }}">
   <head>
     {% block head %}
     <meta charset="utf-8">

--- a/sigal/themes/galleria/templates/index.html
+++ b/sigal/themes/galleria/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ settings.html_language }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/sigal/themes/photoswipe/templates/index.html
+++ b/sigal/themes/photoswipe/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ settings.html_language }}">
   <head>
     {% block head %}
     <meta charset="utf-8">


### PR DESCRIPTION
HTML lang attribute is always set to "en" for all themes. If descriptions are written in french and user agent (browser) is set in french, it may create some strange behaviors : enable browser automatic translations, speech synthesis will use english accent, ...

This PR tries to fix that. I am not a python expert so code I am publishing may surely be improved ;)

