### PR TITLE
Resize portrait images to same size as landscape

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -118,7 +118,13 @@ def generate_image(source, outname, settings, options=None):
             logger.error('Wrong processor name: %s', settings['img_processor'])
             sys.exit()
 
-        processor = processor_cls(*settings['img_size'], upscale=False)
+        width, height = settings['img_size']
+
+        if img.size[0] < img.size[1]:
+            # swap target size if image is in portrait mode
+            height, width = width, height
+
+        processor = processor_cls(width, height, upscale=False)
         img = processor.process(img)
 
     # signal.send() does not work here as plugins can modify the image, so we

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -45,6 +45,32 @@ def test_generate_image(tmpdir):
         assert im.size == size
 
 
+def test_resize_image_portrait(tmpdir):
+    """Test that the area is the same regardless of aspect ratio."""
+    size = (300, 200)
+    settings = create_settings(img_size=size)
+
+    portrait_image = 'm57_the_ring_nebula-587px.jpg'
+    portrait_src = os.path.join(CURRENT_DIR, 'sample', 'pictures', 'dir2', portrait_image)
+    portrait_dst = str(tmpdir.join(portrait_image))
+
+    generate_image(portrait_src, portrait_dst, settings)
+    im = Image.open(portrait_dst)
+
+    # In the default mode, PILKit resizes in a way to never make an image
+    # smaller than either of the lengths, the other is scaled accordingly.
+    # Hence we test that the shorter side has the smallest length.
+    assert im.size[0] == 200
+
+    landscape_image = 'exo20101028-b-full.jpg'
+    landscape_src = os.path.join(CURRENT_DIR, 'sample', 'pictures', 'dir2', landscape_image)
+    landscape_dst = str(tmpdir.join(landscape_image))
+
+    generate_image(landscape_src, landscape_dst, settings)
+    im = Image.open(landscape_dst)
+    assert im.size[1] == 200
+
+
 @pytest.mark.parametrize(("image", "path"), [(TEST_IMAGE, SRCFILE),
                                              (TEST_GIF_IMAGE, SRC_GIF_FILE)])
 def test_generate_image_passthrough(tmpdir, image, path):


### PR DESCRIPTION
With the current approach images are resized along the width, which means images in portrait mode are substantially smaller than landscape images. This change resizes portrait images along the height so that they will cover the exact same area.