### PR TITLE
Add config option for tweaking how thumbnails should be cropped

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Sigal is written and maintained by Simon Conseil and contributors (in
 alphabetical order):
 
+- 3onyc
 - Abdul Qabiz
 - Alexandre Chataignon (@xouillet)
 - Alexey Bazhin

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -131,7 +131,7 @@ def generate_image(source, outname, settings, options=None):
     save_image(img, outname, outformat, options=options, autoconvert=True)
 
 
-def generate_thumbnail(source, outname, box, delay, fit=True, options=None):
+def generate_thumbnail(source, outname, box, delay, fit=True, options=None, thumb_fit_centering=(0.5, 0.5)):
     """Create a thumbnail image."""
 
     logger = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ def generate_thumbnail(source, outname, box, delay, fit=True, options=None):
     original_format = img.format
 
     if fit:
-        img = ImageOps.fit(img, box, PILImage.ANTIALIAS)
+        img = ImageOps.fit(img, box, PILImage.ANTIALIAS, centering=thumb_fit_centering)
     else:
         img.thumbnail(box, PILImage.ANTIALIAS)
 
@@ -171,7 +171,8 @@ def process_image(filepath, outpath, settings):
             thumb_name = os.path.join(outpath, get_thumb(settings, filename))
             generate_thumbnail(outname, thumb_name, settings['thumb_size'],
                                settings['thumb_video_delay'],
-                               fit=settings['thumb_fit'], options=options)
+                               fit=settings['thumb_fit'], options=options,
+                               thumb_fit_centering=settings["thumb_fit_centering"])
     except Exception as e:
         logger.info('Failed to process: %r', e)
         if logger.getEffectiveLevel() == logging.DEBUG:

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -66,6 +66,7 @@ _DEFAULT_CONFIG = {
     'theme': 'colorbox',
     'thumb_dir': 'thumbnails',
     'thumb_fit': True,
+    'thumb_fit_centering': (0.5, 0.5),
     'thumb_prefix': '',
     'thumb_size': (200, 150),
     'thumb_suffix': '',

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -93,6 +93,11 @@ thumb_size = (280, 210)
 # Crop the image to fill the box
 # thumb_fit = True
 
+# When using thumb_fit, specifies what we should crop
+# for usage see
+# http://pillow.readthedocs.io/en/3.1.x/reference/ImageOps.html#PIL.ImageOps.fit
+# thumb_fit_centering = (0.5, 0.5)
+
 # Delay in seconds to avoid black thumbnails in videos with fade-in
 # thumb_video_delay = '0'
 


### PR DESCRIPTION
This pull request allows specifying the `centering` parameter of [`ImageOps.fit`](pillow.readthedocs.io/en/3.1.x/reference/ImageOps.html#PIL.ImageOps.fit) in the config file, allowing for tweaks to how thumbnails are cropped with `thumb_fit = True`.

This is the most basic way I could think of implementing this, there's probably a more elegant way, and I'll gladly change this based on suggestions.