### PR TITLE
add link to get back to toplevel page

### DIFF
--- a/sigal/themes/photoswipe/templates/index.html
+++ b/sigal/themes/photoswipe/templates/index.html
@@ -37,6 +37,7 @@
 			{% if album.breadcrumb %}
 		    <div class="breadcrumb">
 			    <h2>
+                              <a href="/">Home</a> » 
 			      {% for url, title in album.breadcrumb %}
 			      <a href="{{ url }}">{{ title }}</a>{% if not loop.last %} » {% endif %}
 			      {% endfor -%}


### PR DESCRIPTION
Hello,
I tried sigal for the first time and I like it very much. I indexed my whole picture collection (>32k images). In order to be usable for me I needed to add a link to the top-level html page in the template I use.
I propose to merge it into the main sigal.

This is my first pull request ever. That's why I choose a small change. Pls let me know if anything more needs to be considered.
thanks,
Stefan