### PR TITLE
Refactor: configurable file extensions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ alphabetical order):
 - Keith Johnson
 - Lukas Vacek
 - Luke Cyca (@lukecyca)
+- Mate Lakat
 - Matthias Vogelgesang
 - Miroslav Pavleski
 - Nicolas Arnaud-Cormos

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2013      - Christophe-Marie Duquesne
 # Copyright (c) 2014      - Jonas Kaufmann
 # Copyright (c) 2015      - François D.
+# Copyright (c) 2017      - Mate Lakat
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -66,7 +67,6 @@ class Media(UnicodeMixin):
     """
 
     type = ''
-    extensions = ()
 
     def __init__(self, filename, path, settings):
         self.src_filename = self.filename = self.url = filename
@@ -152,7 +152,6 @@ class Image(Media):
     """Gather all informations on an image file."""
 
     type = 'image'
-    extensions = ('.jpg', '.jpeg', '.png', '.gif')
 
     @cached_property
     def date(self):
@@ -188,7 +187,6 @@ class Video(Media):
     """Gather all informations on a video file."""
 
     type = 'video'
-    extensions = ('.mov', '.avi', '.mp4', '.webm', '.ogv', '.3gp')
 
     def __init__(self, filename, path, settings):
         super(Video, self).__init__(filename, path, settings)
@@ -256,9 +254,9 @@ class Album(UnicodeMixin):
 
         for f in filenames:
             ext = splitext(f)[1]
-            if ext.lower() in Image.extensions:
+            if ext.lower() in settings['img_extensions']:
                 media = Image(f, self.path, settings)
-            elif ext.lower() in Video.extensions:
+            elif ext.lower() in settings['video_extensions']:
                 media = Video(f, self.path, settings)
             else:
                 continue
@@ -401,7 +399,7 @@ class Album(UnicodeMixin):
             # find and return the first landscape image
             for f in self.medias:
                 ext = splitext(f.filename)[1]
-                if ext.lower() in Image.extensions:
+                if ext.lower() in self.settings['img_extensions']:
                     # Use f.size if available as it is quicker (in cache), but
                     # fallback to the size of src_path if dst_path is missing
                     size = f.size

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2009-2016 - Simon Conseil
 # Copyright (c) 2013      - Christophe-Marie Duquesne
+# Copyright (c) 2017      - Mate Lakat
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -42,6 +43,7 @@ _DEFAULT_CONFIG = {
     'google_tag_manager': '',
     'ignore_directories': [],
     'ignore_files': [],
+    'img_extensions': ['.jpg', '.jpeg', '.png', '.gif'],
     'img_processor': 'ResizeToFit',
     'img_size': (640, 480),
     'index_in_url': False,
@@ -74,6 +76,7 @@ _DEFAULT_CONFIG = {
     'title': '',
     'use_assets_cdn': True,
     'use_orig': False,
+    'video_extensions': ['.mov', '.avi', '.mp4', '.webm', '.ogv', '.3gp'],
     'video_format': 'webm',
     'video_size': (480, 360),
     'watermark': '',
@@ -108,8 +111,7 @@ def get_thumb(settings, filename):
     path, filen = os.path.split(filename)
     name, ext = os.path.splitext(filen)
 
-    # FIXME: replace this list with Video.extensions
-    if ext.lower() in ('.mov', '.avi', '.mp4', '.webm', '.ogv', '.3gp'):
+    if ext.lower() in settings['video_extensions']:
         ext = '.jpg'
     return join(path, settings['thumb_dir'], settings['thumb_prefix'] +
                 name + settings['thumb_suffix'] + ext)

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -49,6 +49,9 @@ img_size = (800, 600)
 # show_map = False
 # leaflet_provider = 'OpenStreetMap.Mapnik'
 
+# File extensions that should be treated as images
+# img_extensions = ['.jpg', '.jpeg', '.png', '.gif']
+
 # Pilkit processor used to resize the image
 # (see http://pilkit.readthedocs.org/en/latest/#processors)
 # - ResizeToFit: fit the image within the specified dimensions (default)
@@ -135,6 +138,9 @@ ignore_files = []
 # -------------
 # Video options
 # -------------
+
+# File extensions that should be treated as video files
+# video_extensions = ['.mov', '.avi', '.mp4', '.webm', '.ogv', '.3gp']
 
 # Video format
 # specify an alternative format, valid are 'webm' (default) and 'mp4'


### PR DESCRIPTION
This change enables people to configure what file extensions should be
recognised as images and videos by setting:

`img_extensions` and `video_extensions`

fixes #269