### PR TITLE
Add more media.dateobj values and correct documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ alphabetical order):
 - Julien Voisin
 - Kai Fricke
 - Keith Johnson
+- Lee Nelson
 - Lukas Vacek
 - Luke Cyca (@lukecyca)
 - Mate Lakat

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -109,17 +109,60 @@ templates. If available, you can use:
 ``media.exif.fstop``
     The aperture value given as an F-number and formatted as a decimal.
 
-``media.exif.datetime``
+	``media.exif.dateobj``
     The time the image was *taken*. It is a datetime object, that can be
     formatted with ``strftime``:
 
     .. code-block:: jinja
 
-        {% if media.exif.datetime %}
-            {{ media.exif.datetime.strftime('%A, %d. %B %Y') }}
+        {% if media.exif.dateobj %}
+            {{ media.exif.dateobj.strftime('%A, %d. %B %Y') }}
         {% endif %}
 
     This will output something like "Monday, 25. June 2013", depending on your
+    locale.
+
+``media.exif.datetime``
+    The time the image was *taken*. It is formatted as:
+
+    .. code-block:: python
+
+            media.exif.dateobj.strftime('%A, %d. %B %Y')
+
+    This will output something like "Monday, 25. June 2013", depending on your
+    locale.
+
+``media.exif.datetimelocal``
+    The date and time the image was *taken*. It is formatted in the system's
+    configured LOCALE using:
+
+    .. code-block:: python
+
+            media.exif.dateobj.strftime('%c')
+
+    This will output something like "Sat 25 Nov 2017 03:08:17 PM PST",
+    depending on your locale.
+
+``media.exif.datelocal``
+    The date the image was *taken*. It is formatted in the system's
+    configured LOCALE using:
+
+    .. code-block:: python
+
+            media.exif.dateobj.strftime('%x')
+
+    This will output something like "11/25/2017", depending on your
+    locale.
+
+``media.exif.timelocal``
+    The time the image was *taken*. It is formatted in the system's
+    configured LOCALE using:
+
+    .. code-block:: python
+
+            media.exif.dateobj.strftime('%X')
+
+    This will output something like "03:09:39 PM", depending on your
     locale.
 
 ``media.exif.gps``
@@ -135,4 +178,3 @@ templates. If available, you can use:
             <a href="http://openstreetmap.org/index.html?lat={{
             media.exif.gps.lat }}&lon={{ media.exif.long}}">Go to location</a>
         {% endif %}
-

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -312,6 +312,12 @@ def get_exif_tags(data):
             simple['dateobj'] = datetime.strptime(date, '%Y:%m:%d %H:%M:%S')
             dt = simple['dateobj'].strftime('%A, %d. %B %Y')
             simple['datetime'] = dt.decode('utf8') if compat.PY2 else dt
+            dt = simple['dateobj'].strftime('%c')
+            simple['datetimelocal'] = dt.decode('utf8') if compat.PY2 else dt
+            dt = simple['dateobj'].strftime('%x')
+            simple['datelocal'] = dt.decode('utf8') if compat.PY2 else dt
+            dt = simple['dateobj'].strftime('%X')
+            simple['timelocal'] = dt.decode('utf8') if compat.PY2 else dt
         except (ValueError, TypeError) as e:
             logger.info(u'Could not parse DateTimeOriginal: %s', e)
 


### PR DESCRIPTION
As discussed in Issue #271

In the documentation media.dateobj was mistakenly called
media.datetime while media.datetime itself is a string.

Added some more media date related values.  To avoid breaking things,
dateobj and datetime remain unchanged.  datetimelocal, datelocal and
timelocal were added.  As their names imply, they contain values
appropriate for the system's LOCALE.