### PR TITLE
Escape markdown body text

### DIFF
--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -82,7 +82,7 @@ def read_markdown(filename):
                               'markdown.extensions.tables'],
                   output_format='html5')
     # Mark HTML with Markup to prevent jinja2 autoescaping
-    output = {'description': Markup(md.convert(text))}
+    output = {'description': Markup.escape(md.convert(text))}
 
     try:
         meta = md.Meta.copy()


### PR DESCRIPTION
Fix #132.

When an image description was something like

    Title: in"title"

    in"description

sigal would not escape the " in the description, generating html that
looked like

    data-title="in&#34;title"
    data-description="<br><p>in"description</p>...

This would end the attribute quote before the end of the description,
which would truncate it.


I just started using Sigal a couple hours ago, so this might break other things that I don't understand (don't think so though).