### PR TITLE
Add compress assets plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
 install:
     - pip install -U pip setuptools wheel
     - pip install -q $PILLOW
-    - pip install pytest pytest-cov codecov feedgenerator
+    - pip install pytest pytest-cov codecov feedgenerator zopfli brotli
     - pip install .
 
 before_script:

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -34,7 +34,7 @@ class BaseCompressor:
         self.suffix = self.__class__.SUFFIX
 
     def compressed_filename(self, filename):
-        return '{}.{}'.format(os.path.splitext(filename)[0], self.suffix)
+        return '{}.{}'.format(filename, self.suffix)
 
     def do_compress(self, filename, compressed_filename):
         raise NotImplementedError

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -26,10 +26,10 @@ SETTINGS = {
 
 
 class BaseCompressor:
+    suffix = None
 
     def __init__(self, settings):
         self.settings = settings
-        self.suffix = self.__class__.SUFFIX
 
     def do_compress(self, filename, compressed_filename):
         '''
@@ -76,7 +76,7 @@ class BaseCompressor:
 
 
 class GZipCompressor(BaseCompressor):
-    SUFFIX = 'gz'
+    suffix = 'gz'
 
     def do_compress(self, filename, compressed_filename):
         with open(filename, 'rb') as f_in, gzip.open(compressed_filename, 'wb') as f_out:
@@ -84,7 +84,7 @@ class GZipCompressor(BaseCompressor):
 
 
 class ZopfliCompressor(BaseCompressor):
-    SUFFIX = 'gz'
+    suffix = 'gz'
 
     def do_compress(self, filename, compressed_filename):
         import zopfli.gzip
@@ -93,7 +93,7 @@ class ZopfliCompressor(BaseCompressor):
 
 
 class BrotliCompressor(BaseCompressor):
-    SUFFIX = 'br'
+    suffix = 'br'
 
     def do_compress(self, filename, compressed_filename):
         import brotli

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -136,7 +136,7 @@ def compress_assets(assets_directory, compressor):
 
 
 def compress_gallery(gallery):
-    logging.info('Compressing assets for {}'.format(gallery.title))
+    logging.info('Compressing assets for %s', gallery.title)
     settings = SETTINGS.copy()
     settings.update(gallery.settings.get('compress_assets_options', {}))
     compressor = get_compressor(settings)

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -7,8 +7,6 @@ Currently, 3 methods are supported:
 
 """
 
-from __future__ import unicode_literals
-
 import logging
 import gzip
 import shutil
@@ -62,7 +60,7 @@ class BaseCompressor:
 
         file_stats = None
         compressed_stats = None
-        compressed_filename = '{}.{}'.format(filename, self.suffix)
+        compressed_filename = u'{}.{}'.format(filename, self.suffix)
         try:
             file_stats = os.stat(filename)
             compressed_stats = os.stat(compressed_filename)

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -54,7 +54,7 @@ class BaseCompressor:
         try:
             file_stats = os.stat(filename)
             compressed_stats = os.stat(compressed_filename_result)
-        except OSError: # FileNotFoundError is for Python3 only
+        except OSError:  # FileNotFoundError is for Python3 only
             pass
 
         if file_stats and compressed_stats:

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -33,6 +33,7 @@ class BaseCompressor:
 
     def __init__(self, settings):
         self.settings = settings
+        self.suffix = self.__class__.SUFFIX
 
     def compressed_filename(self, filename):
         suffix = self.suffix()
@@ -73,9 +74,7 @@ class BaseCompressor:
 
 
 class GZipCompressor(BaseCompressor):
-
-    def suffix(self):
-        return 'gz'
+    SUFFIX = 'gz'
 
     def do_compress(self, filename, compressed_filename):
         with open(filename, 'rb') as f_in, gzip.open(compressed_filename, 'wb') as f_out:
@@ -83,9 +82,7 @@ class GZipCompressor(BaseCompressor):
 
 
 class ZopfliCompressor(BaseCompressor):
-
-    def suffix(self):
-        return 'gz'
+    SUFFIX = 'gz'
 
     def do_compress(self, filename, compressed_filename):
         with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:
@@ -93,9 +90,7 @@ class ZopfliCompressor(BaseCompressor):
 
 
 class BrotliCompressor(BaseCompressor):
-
-    def suffix(self):
-        return 'br'
+    SUFFIX = 'br'
 
     def do_compress(self, filename, compressed_filename):
         with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -8,6 +8,9 @@ Currently, 3 methods are supported:
     - brotli. Need brotli module from https://pypi.python.org/pypi/Brotli. Brotli is the best compressor for web usage.
 
 """
+
+from __future__ import unicode_literals
+
 import logging
 import gzip
 import shutil

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -38,7 +38,7 @@ class BaseCompressor:
         '''
         raise NotImplementedError
 
-    def compress_file(self, filename):
+    def compress(self, filename):
         '''
         Compress a file, only if needed.
         '''
@@ -132,7 +132,7 @@ def compress_assets(assets_directory, compressor):
 
     with progressbar(assets, label='Compressing theme assets') as progress_compress:
         for filename in progress_compress:
-            compressor.compress_file(filename)
+            compressor.compress(filename)
 
 
 def compress_gallery(gallery):
@@ -146,7 +146,7 @@ def compress_gallery(gallery):
 
     with progressbar(gallery.albums.values(), label='Compressing albums static files') as progress_compress:
         for album in progress_compress:
-            compressor.compress_file(os.path.join(album.dst_path, album.output_file))
+            compressor.compress(os.path.join(album.dst_path, album.output_file))
 
     compress_assets(os.path.join(gallery.settings['destination'], 'static'), compressor)
 

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+"""Plugin to compress static files for faster HTTP transfer.
+
+Currently, 3 methods are supported:
+    - gzip. No dependency required. This is the fastest, but also largest output.
+    - zopfli. Need zopfli module from https://pypi.python.org/pypi/zopfli. gzip compatible output with optimized size.
+    - brotli. Need brotli module from https://pypi.python.org/pypi/Brotli. Brotli is the best compressor for web usage.
+
+"""
+import logging
+import gzip
+import shutil
+import os
+import os.path
+
+from pathlib import Path
+
+from sigal import signals
+from click import progressbar
+
+logger = logging.getLogger(__name__)
+
+SETTINGS = {
+        'suffixes': ['htm', 'html', 'css', 'js', 'svg'],
+        'method': 'gzip',
+        }
+
+
+class BaseCompressor:
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def compressed_filename(self, filename):
+        suffix = self.suffix()
+        return filename.with_name(f'{filename.name}.{suffix}')
+
+    def suffix(self):
+        raise NotImplementedError
+
+    def do_compress(self, filename, compressed_filename):
+        raise NotImplementedError
+
+    def compress_file(self, filename):
+        compressed_filename = self.can_compress(filename)
+        if not compressed_filename:
+            return
+
+        self.do_compress(filename, compressed_filename)
+
+    def can_compress(self, filename):
+        # Be sure it's a path
+        filename = Path(filename)
+        if not filename.suffix[1:] in self.settings['suffixes']:
+            return False
+
+        file_stats = None
+        compressed_stats = None
+        compressed_filename_result = self.compressed_filename(filename)
+        try:
+            file_stats = os.stat(filename)
+            compressed_stats = os.stat(compressed_filename_result)
+        except FileNotFoundError:
+            pass
+
+        if file_stats and compressed_stats:
+            return compressed_filename_result if file_stats.st_mtime > compressed_stats.st_mtime else False
+        else:
+            return compressed_filename_result
+
+
+class GZipCompressor(BaseCompressor):
+
+    def suffix(self):
+        return 'gz'
+
+    def do_compress(self, filename, compressed_filename):
+        with open(filename, 'rb') as f_in, gzip.open(compressed_filename, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+
+class ZopfliCompressor(BaseCompressor):
+
+    def suffix(self):
+        return 'gz'
+
+    def do_compress(self, filename, compressed_filename):
+        with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:
+            f_out.write(zopfli.gzip.compress(f_in.read()))
+
+
+class BrotliCompressor(BaseCompressor):
+
+    def suffix(self):
+        return 'br'
+
+    def do_compress(self, filename, compressed_filename):
+        with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:
+            f_out.write(brotli.compress(f_in.read(), mode=brotli.MODE_TEXT))
+
+
+def get_compressor(settings):
+    name = settings.get('method', '')
+    if name == 'gzip':
+        return GZipCompressor(settings)
+    elif name == 'zopfli':
+        try:
+            global zopfli
+            import zopfli.gzip
+            return ZopfliCompressor(settings)
+        except ImportError:
+            logging.warning('Zopfli not found, using standard gzip')
+            return GZipCompressor(settings)
+
+    elif name == 'brotli':
+        try:
+            global brotli
+            import brotli
+            return BrotliCompressor(settings)
+        except ImportError:
+            logger.error('Unable to import brotli module')
+
+    else:
+        logger.error(f'No such compressor {name}')
+
+
+def compress_assets(assets_directory, compressor):
+    assets = []
+    for current_directory, _, filenames in os.walk(assets_directory):
+        for filename in filenames:
+            assets.append(os.path.join(current_directory, filename))
+
+    with progressbar(assets, label='Compressing theme assets') as progress_compress:
+        for filename in progress_compress:
+            compressor.compress_file(filename)
+
+
+def compress_gallery(gallery):
+    logging.info(f'Compressing assets for {gallery.title}')
+    settings = SETTINGS.copy()
+    settings.update(gallery.settings.get('compress_assets_options', {}))
+    compressor = get_compressor(settings)
+
+    if compressor is None:
+        return
+
+    with progressbar(gallery.albums.values(), label='Compressing albums static files') as progress_compress:
+        for album in progress_compress:
+            compressor.compress_file(os.path.join(album.dst_path, album.output_file))
+
+    compress_assets(os.path.join(gallery.settings['destination'], 'static'), compressor)
+
+
+def register(settings):
+    if settings['write_html']:
+        signals.gallery_build.connect(compress_gallery)

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -16,8 +16,6 @@ import gzip
 import shutil
 import os
 
-from pathlib import Path
-
 from sigal import signals
 from click import progressbar
 
@@ -36,11 +34,7 @@ class BaseCompressor:
         self.suffix = self.__class__.SUFFIX
 
     def compressed_filename(self, filename):
-        suffix = self.suffix()
-        return filename.with_name('{}.{}'.format(filename.name, suffix))
-
-    def suffix(self):
-        raise NotImplementedError
+        return '{}.{}'.format(os.path.splitext(filename)[0], self.suffix)
 
     def do_compress(self, filename, compressed_filename):
         raise NotImplementedError
@@ -53,9 +47,7 @@ class BaseCompressor:
         self.do_compress(filename, compressed_filename)
 
     def can_compress(self, filename):
-        # Be sure it's a path
-        filename = Path(filename)
-        if not filename.suffix[1:] in self.settings['suffixes']:
+        if not os.path.splitext(filename)[1][1:] in self.settings['suffixes']:
             return False
 
         file_stats = None

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -1,9 +1,12 @@
 """Plugin to compress static files for faster HTTP transfer.
 
 Currently, 3 methods are supported:
-    - gzip. No dependency required. This is the fastest, but also largest output.
-    - zopfli. Need zopfli module from https://pypi.python.org/pypi/zopfli. gzip compatible output with optimized size.
-    - brotli. Need brotli module from https://pypi.python.org/pypi/Brotli. Brotli is the best compressor for web usage.
+    - gzip: No dependency required.
+            This is the fastest, but also largest output.
+    - zopfli: Need zopfli module from https://pypi.python.org/pypi/zopfli.
+              gzip compatible output with optimized size.
+    - brotli: Need brotli module from https://pypi.python.org/pypi/Brotli.
+              Brotli is the best compressor for web usage.
 
 """
 

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -64,7 +64,7 @@ class BaseCompressor:
         try:
             file_stats = os.stat(filename)
             compressed_stats = os.stat(compressed_filename_result)
-        except FileNotFoundError:
+        except OSError: # FileNotFoundError is for Python3 only
             pass
 
         if file_stats and compressed_stats:

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Plugin to compress static files for faster HTTP transfer.
 
 Currently, 3 methods are supported:

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Plugin to compress static files for faster HTTP transfer.
+"""Plugin to compress static files for faster HTTP transfer.
 
 Currently, 3 methods are supported:
     - gzip. No dependency required. This is the fastest, but also largest output.

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -33,7 +33,7 @@ class BaseCompressor:
 
     def compressed_filename(self, filename):
         suffix = self.suffix()
-        return filename.with_name(f'{filename.name}.{suffix}')
+        return filename.with_name('{}.{}'.format(filename.name, suffix))
 
     def suffix(self):
         raise NotImplementedError
@@ -121,7 +121,7 @@ def get_compressor(settings):
             logger.error('Unable to import brotli module')
 
     else:
-        logger.error(f'No such compressor {name}')
+        logger.error('No such compressor {}'.format(name))
 
 
 def compress_assets(assets_directory, compressor):
@@ -136,7 +136,7 @@ def compress_assets(assets_directory, compressor):
 
 
 def compress_gallery(gallery):
-    logging.info(f'Compressing assets for {gallery.title}')
+    logging.info('Compressing assets for {}'.format(gallery.title))
     settings = SETTINGS.copy()
     settings.update(gallery.settings.get('compress_assets_options', {}))
     compressor = get_compressor(settings)

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -12,7 +12,6 @@ import logging
 import gzip
 import shutil
 import os
-import os.path
 
 from pathlib import Path
 

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -17,7 +17,7 @@ from click import progressbar
 
 logger = logging.getLogger(__name__)
 
-SETTINGS = {
+DEFAULT_SETTINGS = {
         'suffixes': ['htm', 'html', 'css', 'js', 'svg'],
         'method': 'gzip',
         }
@@ -27,7 +27,7 @@ class BaseCompressor:
     suffix = None
 
     def __init__(self, settings):
-        self.settings = settings
+        self.suffixes_to_compress = settings.get('suffixes', DEFAULT_SETTINGS['suffixes'])
 
     def do_compress(self, filename, compressed_filename):
         '''
@@ -55,7 +55,7 @@ class BaseCompressor:
             - The compressed file exists by is older than the file itself
         Otherwise, it returns False.
         '''
-        if not os.path.splitext(filename)[1][1:] in self.settings['suffixes']:
+        if not os.path.splitext(filename)[1][1:] in self.suffixes_to_compress:
             return False
 
         file_stats = None
@@ -100,7 +100,7 @@ class BrotliCompressor(BaseCompressor):
 
 
 def get_compressor(settings):
-    name = settings.get('method', '')
+    name = settings.get('method', DEFAULT_SETTINGS['method'])
     if name == 'gzip':
         return GZipCompressor(settings)
     elif name == 'zopfli':
@@ -135,9 +135,8 @@ def compress_assets(assets_directory, compressor):
 
 def compress_gallery(gallery):
     logging.info('Compressing assets for %s', gallery.title)
-    settings = SETTINGS.copy()
-    settings.update(gallery.settings.get('compress_assets_options', {}))
-    compressor = get_compressor(settings)
+    compress_settings = gallery.settings.get('compress_assets_options', DEFAULT_SETTINGS)
+    compressor = get_compressor(compress_settings)
 
     if compressor is None:
         return

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -50,7 +50,7 @@ class BaseCompressor:
         '''
         If the given filename should be compressed, returns the compressed filename.
         A file can be compressed if:
-            - It is not a compressed file (using extension)
+            - It is a whitelisted extension
             - The compressed file does not exist
             - The compressed file exists by is older than the file itself
         Otherwise, it returns False.

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -77,6 +77,7 @@ class ZopfliCompressor(BaseCompressor):
     SUFFIX = 'gz'
 
     def do_compress(self, filename, compressed_filename):
+        import zopfli.gzip
         with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:
             f_out.write(zopfli.gzip.compress(f_in.read()))
 
@@ -85,6 +86,7 @@ class BrotliCompressor(BaseCompressor):
     SUFFIX = 'br'
 
     def do_compress(self, filename, compressed_filename):
+        import brotli
         with open(filename, 'rb') as f_in, open(compressed_filename, 'wb') as f_out:
             f_out.write(brotli.compress(f_in.read(), mode=brotli.MODE_TEXT))
 
@@ -95,7 +97,6 @@ def get_compressor(settings):
         return GZipCompressor(settings)
     elif name == 'zopfli':
         try:
-            global zopfli
             import zopfli.gzip
             return ZopfliCompressor(settings)
         except ImportError:
@@ -104,7 +105,6 @@ def get_compressor(settings):
 
     elif name == 'brotli':
         try:
-            global brotli
             import brotli
             return BrotliCompressor(settings)
         except ImportError:

--- a/sigal/plugins/copyright.py
+++ b/sigal/plugins/copyright.py
@@ -5,13 +5,15 @@
 Settings:
 
 - ``copyright``: the copyright text.
-- ``copyright_text_font``: the copyright text font - either system/user font-name or absolute path to font.tff file.
-                           If no font is specified, or specified font is not found, default font is used.
-- ``copyright_text_font_size``: the copyright text font-size. If no font is specified, this setting is ignored.
-- ``copyright_text_color``: the copyright text color in 3 tuple (R, G, B) Decimal RGB code.
-                            e.g. (255, 255, 255) is White.
-- ``copyright_text_position``: the copyright text position in 2 tuple (left, top).
-                               By default text would be positioned at bottom-left corner.
+- ``copyright_text_font``: the copyright text font - either system/user
+  font-name or absolute path to font.ttf file.  If no font is specified, or
+  specified font is not found, the default font is used.
+- ``copyright_text_font_size``: the copyright text font-size. If no font is
+  specified, this setting is ignored.
+- ``copyright_text_color``: the copyright text color in a tuple (R, G, B)
+  with decimal RGB code, e.g. ``(255, 255, 255)`` is white.
+- ``copyright_text_position``: the copyright text position in 2 tuple (left,
+  top).  By default text would be positioned at bottom-left corner.
 
 """
 

--- a/sigal/plugins/nomedia.py
+++ b/sigal/plugins/nomedia.py
@@ -23,8 +23,8 @@
 """ This plugin offers more fine-grained control over exluded images and
 folders, similarly to how it's handled on Android.
 
-To ignore a folder or image put a .nomedia file next to it in its parent folder
-and put its name into the file.  E.g.::
+To ignore a folder or image put a ``.nomedia`` file next to it in its parent
+folder and put its name into the file.  E.g.::
 
     content of folder:
         IMG_3425.JPG, IMG_2426.JPG, IMG_2427.JPG, subfolder, .nomedia
@@ -35,16 +35,16 @@ and put its name into the file.  E.g.::
 
 will ignore all images but IMG_3425.JPG and the subfolder.
 
-Alternatively, if you put a .nomedia file into a folder and leave it blank
-(i.e. an empty file called .nomedia in a folder containing images), this
+Alternatively, if you put a ``.nomedia`` file into a folder and leave it blank
+(i.e. an empty file called ``.nomedia`` in a folder containing images), this
 ignores the whole folder it's located in (like on Android).
 
 WARNING: When you have a pre-existing gallery from a previous run of sigal
-adding a new .nomedia file will not remove the newly ignored images/albums from
-the existing gallery (only the entries in the parent gallery pointing to it).
-They might still be reachable thereafter. Either remove the whole gallery to be
-sure or remove the ignored files/folders inside the gallery to remove them for
-good.
+adding a new ``.nomedia`` file will not remove the newly ignored images/albums
+from the existing gallery (only the entries in the parent gallery pointing to
+it).  They might still be reachable thereafter. Either remove the whole gallery
+to be sure or remove the ignored files/folders inside the gallery to remove
+them for good.
 
 """
 

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -254,3 +254,8 @@ ignore_files = []
 # 	'policy': 'public-read',
 # 	'overwrite': False
 # }
+
+# Settings for compressing static assets
+# compress_assets_options = {
+#    'method': 'gzip' # Or 'zopfli' or 'brotli'
+# }

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -1,0 +1,54 @@
+# -*- coding:utf-8 -*-
+
+import os
+
+import pytest
+
+from sigal.gallery import Gallery
+from sigal import init_plugins
+from sigal.plugins import compress_assets
+
+
+def make_gallery(settings, tmpdir, method):
+    settings['destination'] = str(tmpdir)
+    if "sigal.plugins.compress_assets" not in settings["plugins"]:
+        settings['plugins'] += ["sigal.plugins.compress_assets"]
+
+    # Set method
+    settings.setdefault('compress_assets_options', {})['method'] = method
+
+    compress_options = compress_assets.DEFAULT_SETTINGS.copy()
+    # The key was created by the previous setdefault if needed
+    compress_options.update(settings['compress_assets_options'])
+
+    init_plugins(settings)
+    gal = Gallery(settings)
+    gal.build()
+
+    return compress_options
+
+
+def _test_compress_generic(settings, tmpdir, method, compress_suffix, test_import=None):
+    if test_import:
+        pytest.importorskip(test_import)
+    compress_options = make_gallery(settings, tmpdir, 'gzip')
+
+    suffixes = compress_options['suffixes']
+
+    for path, dirs, files in os.walk(settings['destination']):
+        for file in files:
+            path_exists = os.path.exists('{}.{}'.format(os.path.join(path, file), 'gz'))
+            file_ext = os.path.splitext(file)[1][1:]
+            assert path_exists if file_ext in suffixes else not path_exists
+
+
+def test_compress_gzip(settings, tmpdir):
+    _test_compress_generic(settings, tmpdir, 'gzip', 'gz')
+
+
+def test_compress_zopfli(settings, tmpdir):
+    _test_compress_generic(settings, tmpdir, 'zopfli', 'gz', 'zopfli.gzip')
+
+
+def test_compress_brotli(settings, tmpdir):
+    _test_compress_generic(settings, tmpdir, 'brotli', 'br', 'brotli')

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -8,6 +8,8 @@ from sigal.gallery import Gallery
 from sigal import init_plugins
 from sigal.plugins import compress_assets
 
+CURRENT_DIR = os.path.dirname(__file__)
+
 
 def make_gallery(settings, tmpdir, method):
     settings['destination'] = str(tmpdir)

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -30,7 +30,11 @@ def make_gallery(settings, tmpdir, method):
     return compress_options
 
 
-def _test_compress_generic(settings, tmpdir, method, compress_suffix, test_import=None):
+@pytest.mark.parametrize("method,compress_suffix,test_import",
+                         [('gzip', 'gz', None),
+                          ('zopfli', 'gz', 'zopfli.gzip'),
+                          ('brotli', 'br', 'brotli')])
+def test_compress(settings, tmpdir, method, compress_suffix, test_import):
     if test_import:
         pytest.importorskip(test_import)
     compress_options = make_gallery(settings, tmpdir, 'gzip')
@@ -42,15 +46,3 @@ def _test_compress_generic(settings, tmpdir, method, compress_suffix, test_impor
             path_exists = os.path.exists('{}.{}'.format(os.path.join(path, file), 'gz'))
             file_ext = os.path.splitext(file)[1][1:]
             assert path_exists if file_ext in suffixes else not path_exists
-
-
-def test_compress_gzip(settings, tmpdir):
-    _test_compress_generic(settings, tmpdir, 'gzip', 'gz')
-
-
-def test_compress_zopfli(settings, tmpdir):
-    _test_compress_generic(settings, tmpdir, 'zopfli', 'gz', 'zopfli.gzip')
-
-
-def test_compress_brotli(settings, tmpdir):
-    _test_compress_generic(settings, tmpdir, 'brotli', 'br', 'brotli')

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -14,6 +14,7 @@ CURRENT_DIR = os.path.dirname(__file__)
 
 @pytest.fixture(autouse=True)
 def disconnect_signals():
+    yield None
     for name in dir(signals):
         if not name.startswith('_'):
             try:

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -2,13 +2,26 @@
 
 import os
 
+import blinker
 import pytest
 
+from sigal import init_plugins, signals
 from sigal.gallery import Gallery
-from sigal import init_plugins
 from sigal.plugins import compress_assets
 
 CURRENT_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture(autouse=True)
+def disconnect_signals():
+    for name in dir(signals):
+        if not name.startswith('_'):
+            try:
+                sig = getattr(signals, name)
+                if isinstance(sig, blinker.Signal):
+                    sig.receivers.clear()
+            except Exception:
+                pass
 
 
 def make_gallery(settings, tmpdir, method):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,10 @@
 # -*- coding:utf-8 -*-
 
+import blinker
 import os
 
 from sigal.gallery import Gallery
-from sigal import init_plugins
+from sigal import init_plugins, signals
 
 CURRENT_DIR = os.path.dirname(__file__)
 
@@ -16,9 +17,20 @@ def test_plugins(settings, tmpdir):
     if "sigal.plugins.media_page" not in settings["plugins"]:
         settings['plugins'] += ["sigal.plugins.media_page"]
 
-    init_plugins(settings)
-    gal = Gallery(settings)
-    gal.build()
+    try:
+        init_plugins(settings)
+        gal = Gallery(settings)
+        gal.build()
+    finally:
+        # Reset plugins
+        for name in dir(signals):
+            if not name.startswith('_'):
+                try:
+                    sig = getattr(signals, name)
+                    if isinstance(sig, blinker.Signal):
+                        sig.receivers.clear()
+                except Exception:
+                    pass
 
     out_html = os.path.join(settings['destination'],
                             'dir2', 'exo20101028-b-full.jpg.html')


### PR DESCRIPTION
This plugin will compress static files (html, svg, css, js) in order to be served statically by the web server.
This feature is available in nginx as `gzip_static on;`, but other web servers have similar features.

All HTTP supported encoding are supported : gzip and brotli, with gzip being able to use gzip or zopfli (gzip compatible output with a better compression).