### PR TITLE
[compress_assets] Mission: 100% coverage

### DIFF
--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -88,3 +88,17 @@ def test_compress(disconnect_signals, settings, tmpdir, method,
                     assert not path_exists
                 assert path_exists if file_ext in suffixes else not path_exists
 
+
+@pytest.mark.parametrize("method,compress_suffix,mask",
+                         [('zopfli', 'gz', 'zopfli.gzip'),
+                          ('brotli', 'br', 'brotli'),
+                          ('__does_not_exist__', 'br', None)])
+def test_failed_compress(mask_modules, disconnect_signals, settings, tmpdir,
+                         method, compress_suffix, mask):
+    mask_modules.mask(mask)
+    make_gallery(settings, tmpdir, method)
+
+    for path, dirs, files in os.walk(settings['destination']):
+        for file in files:
+            path_exists = os.path.exists('{}.{}'.format(os.path.join(path, file), compress_suffix))
+            assert not path_exists

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -22,6 +22,10 @@ class ModuleMasker:
         # We should force a reload on next import call.
         for m in modules:
             try:
+                del globals()[m]
+            except KeyError:
+                pass
+            try:
                 del sys.modules[m]
             except KeyError:
                 pass

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -12,6 +12,8 @@ CURRENT_DIR = os.path.dirname(__file__)
 
 def make_gallery(settings, tmpdir, method):
     settings['destination'] = str(tmpdir)
+    # Really speed up testing
+    settings['use_orig'] = True
     if "sigal.plugins.compress_assets" not in settings["plugins"]:
         settings['plugins'] += ["sigal.plugins.compress_assets"]
 

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -11,6 +11,11 @@ from sigal.plugins import compress_assets
 CURRENT_DIR = os.path.dirname(__file__)
 
 
+class ErrorLoader:
+    def load_module(self, fullname):
+        raise ImportError
+
+
 class ModuleMasker:
 
     def __init__(self):
@@ -32,7 +37,7 @@ class ModuleMasker:
 
     def find_module(self, fullname, path=None):
         if fullname in self._modules:
-            raise ImportError
+            return ErrorLoader()
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -60,6 +60,21 @@ def make_gallery(settings, tmpdir, method):
     return compress_options
 
 
+def walk_destination(destination, suffixes, compress_suffix):
+    for path, dirs, files in os.walk(destination):
+        for file in files:
+            original_filename = os.path.join(path, file)
+            compressed_filename = '{}.{}'.format(os.path.join(path, file), compress_suffix)
+            path_exists = os.path.exists(compressed_filename)
+            file_ext = os.path.splitext(file)[1][1:]
+            if file_ext in suffixes:
+                assert path_exists
+                assert os.stat(original_filename).st_mtime <= os.stat(compressed_filename).st_mtime
+            else:
+                assert not path_exists
+            assert path_exists if file_ext in suffixes else not path_exists
+
+
 @pytest.mark.parametrize("method,compress_suffix,test_import",
                          [('gzip', 'gz', None),
                           ('zopfli', 'gz', 'zopfli.gzip'),
@@ -72,21 +87,9 @@ def test_compress(disconnect_signals, settings, tmpdir, method,
     # Compress twice to test compression skip based on mtime
     for _ in range(2):
         compress_options = make_gallery(settings, tmpdir, method)
-
-        suffixes = compress_options['suffixes']
-
-        for path, dirs, files in os.walk(settings['destination']):
-            for file in files:
-                original_filename = os.path.join(path, file)
-                compressed_filename = '{}.{}'.format(os.path.join(path, file), compress_suffix)
-                path_exists = os.path.exists(compressed_filename)
-                file_ext = os.path.splitext(file)[1][1:]
-                if file_ext in suffixes:
-                    assert path_exists
-                    assert os.stat(original_filename).st_mtime <= os.stat(compressed_filename).st_mtime
-                else:
-                    assert not path_exists
-                assert path_exists if file_ext in suffixes else not path_exists
+        walk_destination(settings['destination'],
+                         compress_options['suffixes'],
+                         compress_suffix)
 
 
 @pytest.mark.parametrize("method,compress_suffix,mask",
@@ -97,8 +100,6 @@ def test_failed_compress(mask_modules, disconnect_signals, settings, tmpdir,
                          method, compress_suffix, mask):
     mask_modules.mask(mask)
     make_gallery(settings, tmpdir, method)
-
-    for path, dirs, files in os.walk(settings['destination']):
-        for file in files:
-            path_exists = os.path.exists('{}.{}'.format(os.path.join(path, file), compress_suffix))
-            assert not path_exists
+    walk_destination(settings['destination'],
+                     [],  # No file should be compressed
+                     compress_suffix)

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -43,7 +43,7 @@ class ModuleMasker:
 @pytest.fixture(scope='function')
 def mask_modules():
     masker = ModuleMasker()
-    sys.meta_path.append(masker)
+    sys.meta_path.insert(0, masker)
     yield masker
     sys.meta_path.remove(masker)
 


### PR DESCRIPTION
This will ensure that `compress_assets` plugin is covered at 100% by tests.

To achieve that, there is a fixture that allows module masking: some module will be unavailable while the test function is running. I hope there is no side-effects.

I also set `use_orig` to True (in a832e35d) because this plugin does not care about media processing, and it really speeds tests up.

Achieving 100% coverage for this small module was a funny (but quite easy) game :)