### PR TITLE
Galleria: Load first image earlier

### DIFF
--- a/sigal/themes/galleria/templates/index.html
+++ b/sigal/themes/galleria/templates/index.html
@@ -12,6 +12,15 @@
     <link rel="stylesheet" href="{{ theme.url }}/css/normalize.css">
     <link rel="stylesheet" href="{{ theme.url }}/themes/classic/galleria.classic.css">
     <link rel="stylesheet" href="{{ theme.url }}/css/style.css">
+    {# We will always want to show the first image when we're on an album page #}
+    {# Start loading now for faster document complete instead of waiting for js to load it #}
+    {% if album.medias %}
+    <style>
+    body::after{
+        position:absolute; width:0; height:0; overflow:hidden; z-index:-1;
+	content:url({{ album.medias[0].filename }});
+    }</style>
+    {% endif %}
 
     {% if settings.show_map and album.show_map %}
     <link rel="stylesheet" href="{{ theme.url }}/leaflet/leaflet.css" />


### PR DESCRIPTION
Galleria triggers loading of the main gallery iamge via javascript
which has two problems. It only triggers the load when javascript
has been processed and loads it at the same time as the second and
third image which means it's competing with background images for
bandwidth. We know that the first image will always be seen, so
trigger a load in the document rather than waiting for js to do it.

Comparison (this patch is the only difference between the two runs): https://webpagetest.org/video/compare.php?tests=180303_KS_87bf0854a5a346d90d71fad871ae423c,180302_9A_ff950fed21454ed20fd5e9750d3157ca