### PR TITLE
Try/except in image.py to deal with broken images

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -55,7 +55,11 @@ def _has_exif_tags(img):
 
 def _read_image(file_path):
     with warnings.catch_warnings(record=True) as caught_warnings:
-        im = PILImage.open(file_path)
+        im = None
+        try:
+            im = PILImage.open(file_path)
+        except IOError:
+            print('error reading %s' % file_path)
 
     for warning in caught_warnings:
         if warning.category == PILImage.DecompressionBombWarning:


### PR DESCRIPTION
Corrupt images generate an exception. This patch allows the process to continue, printing out the unreadable filenames.