### PR TITLE
Inlcude tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,4 +11,4 @@ recursive-exclude docs *.pyo
 prune docs/_build
 recursive-include sigal/themes *
 include sigal/templates/sigal.conf.py
-recursive-exclude tests *
+recursive-include tests *


### PR DESCRIPTION
The tests are useful for downstream packagers and do not hurt normal users (because they are usually not run).