### PR TITLE
Remove erroneous double slash from galleria template

### DIFF
--- a/sigal/themes/galleria/templates/index.html
+++ b/sigal/themes/galleria/templates/index.html
@@ -135,7 +135,7 @@
     <script src="{{ theme.url }}/leaflet/leaflet.js"></script>
     <script src="{{ theme.url }}/leaflet/leaflet-providers.js"></script>
     {% endif %}
-    <script src="{{ theme.url }}//galleria.min.js"></script>
+    <script src="{{ theme.url }}/galleria.min.js"></script>
     <script src="{{ theme.url }}/themes/classic/galleria.classic.min.js"></script>
     <script src="{{ theme.url }}/plugins/history/galleria.history.min.js"></script>
     <script>


### PR DESCRIPTION
Some web servers (eg s3) will not serve correct document in this case, so remove double slash to appease.