### PR TITLE
GPS location code-block was incorrect, now working

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -133,8 +133,11 @@ templates. If available, you can use:
     .. code-block:: jinja
 
         {% if media.exif.gps %}
-            <a href="http://openstreetmap.org/index.html?lat={{
-            media.exif.gps.lat }}&lon={{ media.exif.long}}">Go to location</a>
+            <a href="https://www.openstreetmap.org/?mlat={{
+                media.exif.gps.lat }}&mlon={{
+                media.exif.gps.lon }}#map=18/{{
+                media.exif.gps.lat }}/{{
+                media.exif.gps.lon }}">Go to location (OpenStreetMap)</a>
         {% endif %}
 
 


### PR DESCRIPTION
I found that the code was wrong (outdated?). It used
'media.exif.long' when the correct is 'media.exif.gps.lon'.
It was also a bit unuseful since it showed it on the most zoomed
out map (continent level) and no marker.
The current link will go to a faily zoomed in (map=18) and put
a marker in the map.