### PR TITLE
Fixes sigal aborting if image contains malformed metadata

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -235,18 +235,23 @@ def get_exif_data(filename):
 def get_iptc_data(filename):
     """Return a dict with the raw IPTC data."""
 
-    img = _read_image(filename)
-    raw_iptc = IptcImagePlugin.getiptcinfo(img)
-    # IPTC fields are catalogued in:
-    # https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata
     iptc_data = {}
-    # 2:05 is the IPTC title property
-    if raw_iptc and (2, 5) in raw_iptc:
-        iptc_data["title"] = raw_iptc[(2, 5)].decode('utf-8')
 
-    # 2:120 is the IPTC description property
-    if raw_iptc and (2, 120) in raw_iptc:
-        iptc_data["description"] = raw_iptc[(2, 120)].decode('utf-8')
+    try:
+        img = _read_image(filename)
+        raw_iptc = IptcImagePlugin.getiptcinfo(img)
+        # IPTC fields are catalogued in:
+        # https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata
+        # 2:05 is the IPTC title property
+        if raw_iptc and (2, 5) in raw_iptc:
+            iptc_data["title"] = raw_iptc[(2, 5)].decode('utf-8')
+
+        # 2:120 is the IPTC description property
+        if raw_iptc and (2, 120) in raw_iptc:
+            iptc_data["description"] = raw_iptc[(2, 120)].decode('utf-8')
+    except SyntaxError:
+        print("IPTC Error in %s\n"%filename)
+        iptc_data = {}
 
     return iptc_data
 

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -235,6 +235,8 @@ def get_exif_data(filename):
 def get_iptc_data(filename):
     """Return a dict with the raw IPTC data."""
 
+    logger = logging.getLogger(__name__)
+
     iptc_data = {}
 
     # PILs IptcImagePlugin issues a SyntaxError in certain circumstances 
@@ -244,7 +246,7 @@ def get_iptc_data(filename):
         img = _read_image(filename)
         raw_iptc = IptcImagePlugin.getiptcinfo(img)
     except SyntaxError:
-        print("IPTC Error in %s\n"%filename)
+        logger.info('IPTC Error in %s',filename)
 
     # IPTC fields are catalogued in:
     # https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -238,6 +238,7 @@ def get_iptc_data(filename):
     logger = logging.getLogger(__name__)
 
     iptc_data = {}
+    raw_iptc  = {}
 
     # PILs IptcImagePlugin issues a SyntaxError in certain circumstances 
     # with malformed metadata, see PIL/IptcImagePlugin.py", line 71.

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -237,21 +237,24 @@ def get_iptc_data(filename):
 
     iptc_data = {}
 
+    # PILs IptcImagePlugin issues a SyntaxError in certain circumstances 
+    # with malformed metadata, see PIL/IptcImagePlugin.py", line 71.
+    # ( https://github.com/python-pillow/Pillow/blob/9dd0348be2751beb2c617e32ff9985aa2f92ae5f/src/PIL/IptcImagePlugin.py#L71 )
     try:
         img = _read_image(filename)
         raw_iptc = IptcImagePlugin.getiptcinfo(img)
-        # IPTC fields are catalogued in:
-        # https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata
-        # 2:05 is the IPTC title property
-        if raw_iptc and (2, 5) in raw_iptc:
-            iptc_data["title"] = raw_iptc[(2, 5)].decode('utf-8')
-
-        # 2:120 is the IPTC description property
-        if raw_iptc and (2, 120) in raw_iptc:
-            iptc_data["description"] = raw_iptc[(2, 120)].decode('utf-8')
     except SyntaxError:
         print("IPTC Error in %s\n"%filename)
-        iptc_data = {}
+
+    # IPTC fields are catalogued in:
+    # https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata
+    # 2:05 is the IPTC title property
+    if raw_iptc and (2, 5) in raw_iptc:
+        iptc_data["title"] = raw_iptc[(2, 5)].decode('utf-8')
+
+    # 2:120 is the IPTC description property
+    if raw_iptc and (2, 120) in raw_iptc:
+        iptc_data["description"] = raw_iptc[(2, 120)].decode('utf-8')
 
     return iptc_data
 


### PR DESCRIPTION
Currently sigal (or better: Whatever reads the metadata) stops working if it encounters malformed Metadata in a picture. This fix prevents the metadata-reading functions from issueing fatal errors by catching the error, returning empty iptc-data and logging the affected file to the output.