### PR TITLE
Extract IPTC Headline

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -248,6 +248,10 @@ def get_iptc_data(filename):
     if raw_iptc and (2, 120) in raw_iptc:
         iptc_data["description"] = raw_iptc[(2, 120)].decode('utf-8')
 
+    # 2:105 is the IPTC headline property
+    if raw_iptc and (2, 105) in raw_iptc:
+        iptc_data["headline"] = raw_iptc[(2, 105)].decode('utf-8')
+
     return iptc_data
 
 


### PR DESCRIPTION
As noted in the commit message, IPTC Headline (2:105) is the right field for a synopsis of the description, see also [the iptc standard](https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#headline).

This pr adds the extraction of the Headline-field to `get_iptc_data()`.