### PR TITLE
Add a setting to force image output format

### DIFF
--- a/sigal/image.py
+++ b/sigal/image.py
@@ -132,7 +132,9 @@ def generate_image(source, outname, settings, options=None):
     for receiver in signals.img_resized.receivers_for(img):
         img = receiver(img, settings=settings)
 
-    outformat = img.format or original_format or 'JPEG'
+    # first, use hard-coded output format, or PIL format, or original image
+    # format, or fall back to JPEG
+    outformat = settings.get('img_format') or img.format or original_format or 'JPEG'
     logger.debug('Save resized image to %s (%s)', outname, outformat)
     save_image(img, outname, outformat, options=options, autoconvert=True)
 

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -42,6 +42,7 @@ _DEFAULT_CONFIG = {
     'img_extensions': ['.jpg', '.jpeg', '.png', '.gif'],
     'img_processor': 'ResizeToFit',
     'img_size': (640, 480),
+    'img_format': None,
     'index_in_url': False,
     'jpg_options': {'quality': 85, 'optimize': True, 'progressive': True},
     'keep_orig': False,

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -40,6 +40,9 @@ theme = 'galleria'
 # Size of resized image (default: (640, 480))
 img_size = (800, 600)
 
+# Output format of images (default: None, i.e. use input format)
+img_format = "JPEG"
+
 # Show a map of the images where possible?
 # This option only has an effect on the galleria theme for the while.
 # The leaflet_provider setting allow to customize the tile provider (see

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -41,7 +41,7 @@ theme = 'galleria'
 img_size = (800, 600)
 
 # Output format of images (default: None, i.e. use input format)
-img_format = "JPEG"
+# img_format = "JPEG"
 
 # Show a map of the images where possible?
 # This option only has an effect on the galleria theme for the while.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -42,6 +42,17 @@ def test_generate_image(tmpdir):
         im = Image.open(dstfile)
         assert im.size == size
 
+def test_generate_image_imgformat(tmpdir):
+    "Test the effects of the img_format setting on generate_image."
+
+    dstfile = str(tmpdir.join(TEST_IMAGE))
+    for i, outfmt in enumerate(["JPEG", "PNG", "TIFF"]):
+        settings = create_settings(img_size=(300,300), img_processor='ResizeToFill',
+                                   copy_exif_data=True, img_format=outfmt)
+        options = {'quality': 85}
+        generate_image(SRCFILE, dstfile, settings, options=options)
+        im = Image.open(dstfile)
+        assert im.format == outfmt
 
 def test_resize_image_portrait(tmpdir):
     """Test that the area is the same regardless of aspect ratio."""


### PR DESCRIPTION
It seems that sigal uses the format of input images for each output image. This new setting allows one to hard-code the output format of all images in the settings.conf.py.

My use case: I develop images to tiffs, and many browsers dont' like tiffs it seems. Now I can force JPEG output for all images, and browsers are happy to display them.

Thanks,
Kevin