### PR TITLE
Performance: Read all metadata at once

### DIFF
--- a/docs/changelog.py
+++ b/docs/changelog.py
@@ -35,6 +35,7 @@ From the bash command line with $GITHUB token::
 
 import os
 import re
+
 from git import Repo
 from github import Github
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ Released on 2019-xx-xx.
 - Add a quiet flag [:issue:`376`].
 - Make sure that read-only files can be copied [:issue:`375`].
 - Update photoswipe to v4.1.3
+- Add a setting to force image output format [:issue:`360`].
+- Improve error message when template is not found [:issue:`384`].
 
 Version 2.0
 ~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,9 @@
 import os
 import sys
 
-import alabaster
 from pkg_resources import get_distribution
+
+import alabaster
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+
 from setuptools import setup
 
 if sys.version_info[:2] < (3, 6):

--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -18,7 +18,6 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import click
 import importlib
 import locale
 import logging
@@ -26,10 +25,11 @@ import os
 import socketserver
 import sys
 import time
-
-from click import argument, option
 from http import server
-from pkg_resources import get_distribution, DistributionNotFound
+
+import click
+from click import argument, option
+from pkg_resources import DistributionNotFound, get_distribution
 
 from .gallery import Gallery
 from .log import init_logging

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -40,8 +40,7 @@ from urllib.parse import quote as url_quote
 from click import get_terminal_size, progressbar
 
 from . import image, signals, video
-from .image import (get_exif_data, get_exif_tags, get_image_metadata,
-                    get_iptc_data, get_size, process_image)
+from .image import get_exif_tags, get_image_metadata, get_size, process_image
 from .settings import get_thumb
 from .utils import (Devnull, cached_property, check_or_create_dir, copy,
                     get_mime, is_valid_html5_video, read_markdown,

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -31,23 +31,23 @@ import os
 import pickle
 import random
 import sys
-
-from click import progressbar, get_terminal_size
 from collections import defaultdict
 from datetime import datetime
 from itertools import cycle
 from os.path import isfile, join, splitext
 from urllib.parse import quote as url_quote
 
-from . import image, video, signals
-from .image import (process_image, get_exif_tags, get_exif_data, get_size,
-                    get_iptc_data)
+from click import get_terminal_size, progressbar
+
+from . import image, signals, video
+from .image import (get_exif_data, get_exif_tags, get_iptc_data, get_size,
+                    process_image)
 from .settings import get_thumb
-from .utils import (Devnull, copy, check_or_create_dir, url_from_path,
-                    read_markdown, cached_property, is_valid_html5_video,
-                    get_mime)
+from .utils import (Devnull, cached_property, check_or_create_dir, copy,
+                    get_mime, is_valid_html5_video, read_markdown,
+                    url_from_path)
 from .video import process_video
-from .writer import AlbumPageWriter, AlbumListPageWriter
+from .writer import AlbumListPageWriter, AlbumPageWriter
 
 
 class Media:

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -56,6 +56,10 @@ def _has_exif_tags(img):
 
 
 def _read_image(file_path):
+    # The image is already opened
+    if isinstance(file_path, PILImage.Image):
+        return file_path
+
     with warnings.catch_warnings(record=True) as caught_warnings:
         im = PILImage.open(file_path)
 
@@ -269,6 +273,43 @@ def get_iptc_data(filename):
                                                           errors='replace')
 
     return iptc_data
+
+
+def get_image_metadata(filename):
+    logger = logging.getLogger(__name__)
+    try:
+        img = _read_image(filename)
+    except Exception as e:
+        logger.error('Could not open image %s metadata: %s',
+                     filename, e)
+
+    exif = None
+    iptc = None
+    size = None
+
+    try:
+        exif = get_exif_data(img)
+    except Exception as e:
+        logger.warning('Could not read EXIF data from %s: %s',
+                       filename, e)
+
+    try:
+        iptc = get_iptc_data(img)
+    except Exception as e:
+        logger.warning('Could not read IPTC data from %s: %s',
+                       filename, e)
+
+    try:
+        size = get_size(img)
+    except Exception as e:
+        logger.warning('Could not read size from %s: %s',
+                       filename, e)
+
+    return {
+            'exif': exif,
+            'iptc': iptc,
+            'size': size,
+            }
 
 
 def dms_to_degrees(v):

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -207,10 +207,7 @@ def get_size(file_path):
         logger.error("Could not read size of %s due to %r", file_path, e)
     else:
         width, height = im.size
-        return {
-            'width': width,
-            'height': height
-        }
+        return {'width': width, 'height': height}
 
 
 def get_exif_data(filename):
@@ -280,36 +277,28 @@ def get_image_metadata(filename):
     try:
         img = _read_image(filename)
     except Exception as e:
-        logger.error('Could not open image %s metadata: %s',
-                     filename, e)
-
-    exif = None
-    iptc = None
-    size = None
+        logger.error('Could not open image %s metadata: %s', filename, e)
+        return {'exif': None, 'iptc': None, 'size': None}
 
     try:
         exif = get_exif_data(img)
     except Exception as e:
-        logger.warning('Could not read EXIF data from %s: %s',
-                       filename, e)
+        logger.warning('Could not read EXIF data from %s: %s', filename, e)
+        exif = {}
 
     try:
         iptc = get_iptc_data(img)
     except Exception as e:
-        logger.warning('Could not read IPTC data from %s: %s',
-                       filename, e)
+        logger.warning('Could not read IPTC data from %s: %s', filename, e)
+        iptc = {}
 
     try:
         size = get_size(img)
     except Exception as e:
-        logger.warning('Could not read size from %s: %s',
-                       filename, e)
+        logger.warning('Could not read size from %s: %s', filename, e)
+        size = {}
 
-    return {
-            'exif': exif,
-            'iptc': iptc,
-            'size': size,
-            }
+    return {'exif': exif, 'iptc': iptc, 'size': size}
 
 
 def dms_to_degrees(v):

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -29,22 +29,23 @@
 #
 # and partially modified. The code in question is licensed under MIT license.
 
+import fractions
 import logging
 import os
-import pilkit.processors
 import sys
 import warnings
-import fractions
-
 from copy import deepcopy
 from datetime import datetime
-from PIL.ExifTags import TAGS, GPSTAGS
-from PIL import Image as PILImage, ImageOps, ImageFile, IptcImagePlugin
+
+import pilkit.processors
+from PIL import Image as PILImage
+from PIL import ImageFile, ImageOps, IptcImagePlugin
+from PIL.ExifTags import GPSTAGS, TAGS
 from pilkit.processors import Transpose
 from pilkit.utils import save_image
 
 from . import signals, utils
-from .settings import get_thumb, Status
+from .settings import Status, get_thumb
 
 # Force loading of truncated files
 ImageFile.LOAD_TRUNCATED_IMAGES = True

--- a/sigal/image.py
+++ b/sigal/image.py
@@ -274,29 +274,28 @@ def get_iptc_data(filename):
 
 def get_image_metadata(filename):
     logger = logging.getLogger(__name__)
+    exif, iptc, size = {}, {}, {}
+
     try:
         img = _read_image(filename)
     except Exception as e:
         logger.error('Could not open image %s metadata: %s', filename, e)
-        return {'exif': None, 'iptc': None, 'size': None}
+    else:
+        try:
+            if os.path.splitext(filename)[1].lower() in ('.jpg', '.jpeg'):
+                exif = get_exif_data(img)
+        except Exception as e:
+            logger.warning('Could not read EXIF data from %s: %s', filename, e)
 
-    try:
-        exif = get_exif_data(img)
-    except Exception as e:
-        logger.warning('Could not read EXIF data from %s: %s', filename, e)
-        exif = {}
+        try:
+            iptc = get_iptc_data(img)
+        except Exception as e:
+            logger.warning('Could not read IPTC data from %s: %s', filename, e)
 
-    try:
-        iptc = get_iptc_data(img)
-    except Exception as e:
-        logger.warning('Could not read IPTC data from %s: %s', filename, e)
-        iptc = {}
-
-    try:
-        size = get_size(img)
-    except Exception as e:
-        logger.warning('Could not read size from %s: %s', filename, e)
-        size = {}
+        try:
+            size = get_size(img)
+        except Exception as e:
+            logger.warning('Could not read size from %s: %s', filename, e)
 
     return {'exif': exif, 'iptc': iptc, 'size': size}
 

--- a/sigal/log.py
+++ b/sigal/log.py
@@ -21,7 +21,6 @@
 import logging
 import os
 import sys
-
 from logging import Formatter
 
 # The background is set with 40 plus the number of the color, and the

--- a/sigal/plugins/adjust.py
+++ b/sigal/plugins/adjust.py
@@ -14,8 +14,10 @@ Settings::
 """
 
 import logging
-from sigal import signals
+
 from pilkit.processors import Adjust
+
+from sigal import signals
 
 logger = logging.getLogger(__name__)
 

--- a/sigal/plugins/compress_assets.py
+++ b/sigal/plugins/compress_assets.py
@@ -27,13 +27,14 @@ Settings available as dictionary in ``compress_assets_options``:
 
 """
 
-import logging
 import gzip
-import shutil
+import logging
 import os
+import shutil
+
+from click import progressbar
 
 from sigal import signals
-from click import progressbar
 
 logger = logging.getLogger(__name__)
 

--- a/sigal/plugins/copyright.py
+++ b/sigal/plugins/copyright.py
@@ -16,8 +16,9 @@ Settings:
 """
 
 import logging
-from PIL import ImageDraw
-from PIL import ImageFont
+
+from PIL import ImageDraw, ImageFont
+
 from sigal import signals
 
 logger = logging.getLogger(__name__)

--- a/sigal/plugins/extended_caching.py
+++ b/sigal/plugins/extended_caching.py
@@ -29,9 +29,10 @@ creation of index files dramatically.
 
 """
 
-import pickle
 import logging
 import os
+import pickle
+
 from sigal import signals
 
 logger = logging.getLogger(__name__)

--- a/sigal/plugins/feeds.py
+++ b/sigal/plugins/feeds.py
@@ -18,10 +18,11 @@ Example::
 
 import logging
 import os
-
 from datetime import datetime
+
 from feedgenerator import Atom1Feed, Rss201rev2Feed
 from jinja2 import Markup
+
 from sigal import signals
 
 logger = logging.getLogger(__name__)

--- a/sigal/plugins/media_page.py
+++ b/sigal/plugins/media_page.py
@@ -32,8 +32,8 @@ previous/next :class:`~sigal.gallery.Media` objects.
 import os
 
 from sigal import signals
-from sigal.writer import AbstractWriter
 from sigal.utils import url_from_path
+from sigal.writer import AbstractWriter
 
 
 class PageWriter(AbstractWriter):

--- a/sigal/plugins/nomedia.py
+++ b/sigal/plugins/nomedia.py
@@ -48,6 +48,7 @@ them for good.
 
 import logging
 import os
+
 from sigal import signals
 
 logger = logging.getLogger(__name__)

--- a/sigal/plugins/upload_s3.py
+++ b/sigal/plugins/upload_s3.py
@@ -22,10 +22,10 @@ Settings (all settings are wrapped in ``upload_s3_options`` dict):
 
 """
 
-import boto
 import logging
 import os
 
+import boto
 from boto.s3.key import Key
 from click import progressbar
 

--- a/sigal/plugins/watermark.py
+++ b/sigal/plugins/watermark.py
@@ -35,7 +35,9 @@ Settings:
 """
 
 import logging
+
 from PIL import Image, ImageEnhance
+
 from sigal import signals
 
 

--- a/sigal/plugins/zip_gallery.py
+++ b/sigal/plugins/zip_gallery.py
@@ -31,11 +31,12 @@ present, then make a ZIP archive with all media files.
 
 import logging
 import os
+import zipfile
 from os.path import isfile, join, splitext
+
 from sigal import signals
 from sigal.gallery import Album
 from sigal.utils import cached_property
-import zipfile
 
 logger = logging.getLogger(__name__)
 

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -25,7 +25,6 @@ import os
 from os.path import abspath, isabs, join, normpath
 from pprint import pformat
 
-
 _DEFAULT_CONFIG = {
     'albums_sort_attr': 'name',
     'albums_sort_reverse': False,

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -20,10 +20,10 @@
 
 import os
 import shutil
+from urllib.parse import quote
+
 from markdown import Markdown
 from markupsafe import Markup
-
-from urllib.parse import quote
 
 VIDEO_MIMES = {'.mp4': 'video/mp4',
                '.webm': 'video/webm',

--- a/sigal/video.py
+++ b/sigal/video.py
@@ -27,7 +27,7 @@ import subprocess
 from os.path import splitext
 
 from . import image, utils
-from .settings import get_thumb, Status
+from .settings import Status, get_thumb
 from .utils import is_valid_html5_video
 
 

--- a/sigal/writer.py
+++ b/sigal/writer.py
@@ -20,15 +20,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import jinja2
-import logging
 import imp
+import logging
 import os
 import sys
 import types
-
 from distutils.dir_util import copy_tree
-from jinja2 import Environment, FileSystemLoader, ChoiceLoader, PrefixLoader
+
+import jinja2
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
 from jinja2.exceptions import TemplateNotFound
 
 from .utils import url_from_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
-import blinker
 import os
+import shutil
+
+import blinker
 import PIL
 import pytest
-import shutil
 
 from sigal import signals
 from sigal.settings import read_settings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,10 @@
 import logging
 import os
-from click.testing import CliRunner
 from os.path import join
 
-from sigal import init, build, serve, set_meta
+from click.testing import CliRunner
+
+from sigal import build, init, serve, set_meta
 
 TESTGAL = join(os.path.abspath(os.path.dirname(__file__)), 'sample')
 

--- a/tests/test_compress_assets_plugin.py
+++ b/tests/test_compress_assets_plugin.py
@@ -1,6 +1,5 @@
 import os
 import sys
-
 from unittest import mock
 
 import pytest

--- a/tests/test_extended_caching.py
+++ b/tests/test_extended_caching.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+
 import pytest
 
 from sigal.gallery import Gallery

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,11 +1,12 @@
+import datetime
 import logging
 import os
-import pytest
-import datetime
-
 from os.path import join
 from urllib.parse import quote
-from sigal.gallery import Album, Media, Image, Video, Gallery
+
+import pytest
+
+from sigal.gallery import Album, Gallery, Image, Media, Video
 from sigal.video import SubprocessException
 
 CURRENT_DIR = os.path.dirname(__file__)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,12 +1,13 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 from PIL import Image
 
 from sigal import init_logging
-from sigal.image import (generate_image, generate_thumbnail, get_exif_tags,
-                         get_exif_data, get_size, process_image, get_iptc_data)
-from sigal.settings import create_settings, Status
+from sigal.image import (generate_image, generate_thumbnail, get_exif_data,
+                         get_exif_tags, get_iptc_data, get_size, process_image)
+from sigal.settings import Status, create_settings
 
 CURRENT_DIR = os.path.dirname(__file__)
 TEST_IMAGE = 'KeckObservatory20071020.jpg'

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,7 +1,7 @@
 import os
 
-from sigal.gallery import Gallery
 from sigal import init_plugins
+from sigal.gallery import Gallery
 
 CURRENT_DIR = os.path.dirname(__file__)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,6 @@
 import os
 
-from sigal.settings import read_settings, get_thumb
+from sigal.settings import get_thumb, read_settings
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+
 from sigal import utils
 
 CURRENT_DIR = os.path.dirname(__file__)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,8 +1,9 @@
 import os
+
 import pytest
 
-from sigal.video import video_size, generate_video, process_video
-from sigal.settings import create_settings, Status
+from sigal.settings import Status, create_settings
+from sigal.video import generate_video, process_video, video_size
 
 CURRENT_DIR = os.path.dirname(__file__)
 TEST_VIDEO = 'example video.ogv'

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -1,5 +1,5 @@
-import os
 import glob
+import os
 import zipfile
 
 from sigal import init_plugins


### PR DESCRIPTION
This will reduce the need to call PIL.Image.open, which is by far the heavier part when doing an idle build.

On my gallery with 536 images and 46 videos, I'm experiencing an improvement of ~28% faster build when writing only HTML.