### PR TITLE
Performance: Disable MPO loading

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -34,7 +34,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 from .gallery import Gallery
 from .log import init_logging
 from .settings import read_settings
-from .utils import copy
+from .utils import copy, monkey_patch_pil_jpeg_mpo
 
 try:
     __version__ = get_distribution(__name__).version
@@ -138,6 +138,8 @@ def build(source, destination, debug, verbose, force, config, theme, title,
         logger.error("Output directory should be outside of the input "
                      "directory.")
         sys.exit(1)
+
+    monkey_patch_pil_jpeg_mpo()
 
     if title:
         settings['title'] = title

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -135,3 +135,14 @@ class cached_property(object):
             return self
         value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
+
+
+def monkey_patch_pil_jpeg_mpo():
+    from PIL import Image
+    from PIL.JpegImagePlugin import JpegImageFile
+
+    def jpeg_factory(fp=None, filename=None):
+        im = JpegImageFile(fp, filename)
+        return im
+
+    Image.OPEN[JpegImageFile.format] = (jpeg_factory, Image.OPEN[JpegImageFile.format][1])


### PR DESCRIPTION
This one is less obvious than #362.

In [Pillow JpegImagePlugin](https://github.com/python-pillow/Pillow/blob/43ed7b29c9cffbcb05763bc29ddfc48af5db3f80/src/PIL/JpegImagePlugin.py#L778), if some headers match, then it opens the image again using `MpoImagePlugin`. In my current collection, all images are detected as such, but they are not. It leads to a double JPEG marker parsing, for nothing.

This patch disables this behavior. It can be difficult to merge for two reasons:
- It is monkey patching
- Some people might actually need to read MPO for some reason that I don't know about

In my collections of 536 images and 46 videos, I experienced a gain of 42% in speed in idle build (without applying #326). This is a huge win in this use case.