### PR TITLE
Performance: Do not store attribute in TIFF new API

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -34,7 +34,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 from .gallery import Gallery
 from .log import init_logging
 from .settings import read_settings
-from .utils import copy
+from .utils import copy, monkey_patch_pil_tiff_imagefiledirectory_v1
 
 try:
     __version__ = get_distribution(__name__).version
@@ -138,6 +138,8 @@ def build(source, destination, debug, verbose, force, config, theme, title,
         logger.error("Output directory should be outside of the input "
                      "directory.")
         sys.exit(1)
+
+    monkey_patch_pil_tiff_imagefiledirectory_v1()
 
     if title:
         settings['title'] = title


### PR DESCRIPTION
The end of my current performance improvement, after #362, #363 and #364.

This one should **not** be merged as-is for the following reasons:
- It is removing the use of the [`v2` TIFF API](https://github.com/python-pillow/Pillow/blob/43ed7b29c9cffbcb05763bc29ddfc48af5db3f80/src/PIL/TiffImagePlugin.py#L935) in the `v1` API. It is completely safe for JpegImagePlugin, which makes only use of it, but I don't know the status of other plugins.
- It is monkey patching.

However, I exposed this to show that on my gallery with 536 images and 46 videos, I'm experiencing a boost of 32% in speed for idle builds.

With all other mentionned patches, I'm going from idle build in 3.23 seconds in master to 1.06 second. It is roughly one-third of the current situation.

Sometimes, it seems that Pillow is not focused on speed, so that's why monkey patching could be allowed (e.g. for #363). This one could be proposed as an option in the configuration.