### PR TITLE
Add new plugin to allow one to disable ZIP generation on a per album basis

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -119,6 +119,11 @@ Nomedia plugin
 
 .. automodule:: sigal.plugins.nomedia
 
+No ZIP Gallery plugin
+=====================
+
+.. automodule:: sigal.plugins.nozip_gallery
+
 Upload to S3 plugin
 ===================
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -2,6 +2,8 @@
  Plugins
 =========
 
+.. contents::
+
 How to use plugins
 ------------------
 
@@ -119,11 +121,6 @@ Nomedia plugin
 
 .. automodule:: sigal.plugins.nomedia
 
-ZIP Gallery plugin
-==================
-
-.. automodule:: sigal.plugins.zip_gallery
-
 Upload to S3 plugin
 ===================
 
@@ -133,3 +130,8 @@ Watermark plugin
 ================
 
 .. automodule:: sigal.plugins.watermark
+
+ZIP Gallery plugin
+==================
+
+.. automodule:: sigal.plugins.zip_gallery

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -119,10 +119,10 @@ Nomedia plugin
 
 .. automodule:: sigal.plugins.nomedia
 
-No ZIP Gallery plugin
-=====================
+ZIP Gallery plugin
+==================
 
-.. automodule:: sigal.plugins.nozip_gallery
+.. automodule:: sigal.plugins.zip_gallery
 
 Upload to S3 plugin
 ===================

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -267,6 +267,7 @@ class Album:
         self.settings = settings
         self.subdirs = dirnames
         self.output_file = settings['output_filename']
+        self.disable_zip_gallery = False
         self._thumbnail = None
 
         if path == '.':
@@ -527,6 +528,12 @@ class Album:
         archive with all original images of the corresponding directory.
 
         """
+
+        if self.disable_zip_gallery:
+            # ZIP file generation has been explicitly disabled
+            # by a .nozip_gallery file for instance
+            return
+
         zip_gallery = self.settings['zip_gallery']
 
         if zip_gallery and len(self) > 0:

--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -31,7 +31,6 @@ import os
 import pickle
 import random
 import sys
-import zipfile
 
 from click import progressbar, get_terminal_size
 from collections import defaultdict
@@ -267,7 +266,6 @@ class Album:
         self.settings = settings
         self.subdirs = dirnames
         self.output_file = settings['output_filename']
-        self.disable_zip_gallery = False
         self._thumbnail = None
 
         if path == '.':
@@ -522,43 +520,10 @@ class Album:
 
     @cached_property
     def zip(self):
-        """Make a ZIP archive with all media files and return its path.
-
-        If the ``zip_gallery`` setting is set,it contains the location of a zip
-        archive with all original images of the corresponding directory.
-
+        """Placeholder ZIP method.
+        The ZIP logic is controlled by the zip_gallery plugin
         """
-
-        if self.disable_zip_gallery:
-            # ZIP file generation has been explicitly disabled
-            # by a .nozip_gallery file for instance
-            return
-
-        zip_gallery = self.settings['zip_gallery']
-
-        if zip_gallery and len(self) > 0:
-            zip_gallery = zip_gallery.format(album=self)
-            archive_path = join(self.dst_path, zip_gallery)
-            if (self.settings.get('zip_skip_if_exists', False) and
-                    isfile(archive_path)):
-                self.logger.debug("Archive %s already created, passing",
-                                  archive_path)
-                return zip_gallery
-
-            archive = zipfile.ZipFile(archive_path, 'w', allowZip64=True)
-            attr = ('src_path' if self.settings['zip_media_format'] == 'orig'
-                    else 'dst_path')
-
-            for p in self:
-                path = getattr(p, attr)
-                try:
-                    archive.write(path, os.path.split(path)[1])
-                except OSError as e:
-                    self.logger.warn('Failed to add %s to the ZIP: %s', p, e)
-
-            archive.close()
-            self.logger.debug('Created ZIP archive %s', archive_path)
-            return zip_gallery
+        return None
 
 
 class Gallery(object):

--- a/sigal/plugins/nozip_gallery.py
+++ b/sigal/plugins/nozip_gallery.py
@@ -1,0 +1,45 @@
+# Copyright 2019 - Remi Ferrand
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+""" This plugin offers the ability to disable ZIP gallery generation on a per album
+granularity.
+
+To ignore a ZIP gallery generation for a particular album, put a ``.nozip_gallery`` file next to it in its parent
+folder. Only the existence of this ``.nozip_gallery`` file is tested.
+"""
+
+import logging
+import os
+from sigal import signals
+
+logger = logging.getLogger(__name__)
+
+def nozip_galery_file(album, settings=None):
+    """Filesystem based switch to disable ZIP generation for an Album"""
+    nozipgallerypath = os.path.join(album.src_path, ".nozip_gallery")
+
+    if os.path.isfile(nozipgallerypath):
+        logger.info("Ignoring ZIP gallery generation for album '%s' because of present "
+                    ".nozip_gallery file", album.name)
+
+        album.disable_zip_gallery = True
+
+def register(settings):
+    signals.album_initialized.connect(nozip_galery_file)

--- a/sigal/plugins/zip_gallery.py
+++ b/sigal/plugins/zip_gallery.py
@@ -20,13 +20,13 @@
 
 """ This plugin controls the generation of a ZIP archive for a gallery
 
+If the ``zip_gallery`` setting is set, it contains the location of a zip
+archive with all original images of the corresponding directory.
+
 To ignore a ZIP gallery generation for a particular album, put
 a ``.nozip_gallery`` file next to it in its parent folder. Only the existence
-of this ``.nozip_gallery`` file is tested.  If no .nozip_gallery file is
+of this ``.nozip_gallery`` file is tested.  If no ``.nozip_gallery`` file is
 present, then make a ZIP archive with all media files.
-
-If the ``zip_gallery`` setting is set,it contains the location of a zip
-archive with all original images of the corresponding directory.
 """
 
 import logging

--- a/sigal/plugins/zip_gallery.py
+++ b/sigal/plugins/zip_gallery.py
@@ -22,6 +22,10 @@
 
 To ignore a ZIP gallery generation for a particular album, put a ``.nozip_gallery`` file next to it in its parent
 folder. Only the existence of this ``.nozip_gallery`` file is tested.
+If no .nozip_fallery file is present, then make a ZIP archive with all media files.
+
+If the ``zip_gallery`` setting is set,it contains the location of a zip
+archive with all original images of the corresponding directory.
 """
 
 import logging

--- a/sigal/plugins/zip_gallery.py
+++ b/sigal/plugins/zip_gallery.py
@@ -22,7 +22,7 @@
 
 To ignore a ZIP gallery generation for a particular album, put
 a ``.nozip_gallery`` file next to it in its parent folder. Only the existence
-of this ``.nozip_gallery`` file is tested.  If no .nozip_fallery file is
+of this ``.nozip_gallery`` file is tested.  If no .nozip_gallery file is
 present, then make a ZIP archive with all media files.
 
 If the ``zip_gallery`` setting is set,it contains the location of a zip

--- a/sigal/plugins/zip_gallery.py
+++ b/sigal/plugins/zip_gallery.py
@@ -20,9 +20,10 @@
 
 """ This plugin controls the generation of a ZIP archive for a gallery
 
-To ignore a ZIP gallery generation for a particular album, put a ``.nozip_gallery`` file next to it in its parent
-folder. Only the existence of this ``.nozip_gallery`` file is tested.
-If no .nozip_fallery file is present, then make a ZIP archive with all media files.
+To ignore a ZIP gallery generation for a particular album, put
+a ``.nozip_gallery`` file next to it in its parent folder. Only the existence
+of this ``.nozip_gallery`` file is tested.  If no .nozip_fallery file is
+present, then make a ZIP archive with all media files.
 
 If the ``zip_gallery`` setting is set,it contains the location of a zip
 archive with all original images of the corresponding directory.
@@ -57,8 +58,7 @@ def _generate_album_zip(album):
         archive_path = join(album.dst_path, zip_gallery)
         if (album.settings.get('zip_skip_if_exists', False) and
                 isfile(archive_path)):
-            album.logger.debug("Archive %s already created, passing",
-                              archive_path)
+            logger.debug("Archive %s already created, passing", archive_path)
             return zip_gallery
 
         archive = zipfile.ZipFile(archive_path, 'w', allowZip64=True)
@@ -70,10 +70,10 @@ def _generate_album_zip(album):
             try:
                 archive.write(path, os.path.split(path)[1])
             except OSError as e:
-                album.logger.warn('Failed to add %s to the ZIP: %s', p, e)
+                logger.warn('Failed to add %s to the ZIP: %s', p, e)
 
         archive.close()
-        album.logger.debug('Created ZIP archive %s', archive_path)
+        logger.debug('Created ZIP archive %s', archive_path)
         return zip_gallery
 
     return False
@@ -89,15 +89,15 @@ def generate_album_zip(album):
 
     # check if ZIP file generation as been disabled by .nozip_gallery file
     if not _should_generate_album_zip(album):
-        album.logger.info("Ignoring ZIP gallery generation for album '%s' because of present "
-                          ".nozip_gallery file", album.name)
+        logger.info("Ignoring ZIP gallery generation for album '%s' because of present "
+                    ".nozip_gallery file", album.name)
         return False
 
     return _generate_album_zip(album)
 
-def nozip_galery_file(album, settings=None):
+def nozip_gallery_file(album, settings=None):
     """Filesystem based switch to disable ZIP generation for an Album"""
     Album.zip = cached_property(generate_album_zip)
 
 def register(settings):
-    signals.album_initialized.connect(nozip_galery_file)
+    signals.album_initialized.connect(nozip_gallery_file)

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -9,9 +9,15 @@ links = [('Example link', 'http://example.org'),
 
 files_to_copy = (('../watermark.png', 'watermark.png'),)
 
-plugins = ['sigal.plugins.adjust', 'sigal.plugins.copyright',
-           'sigal.plugins.watermark', 'sigal.plugins.feeds',
-           'sigal.plugins.nomedia', 'sigal.plugins.extended_caching']
+plugins = [
+    'sigal.plugins.adjust',
+    'sigal.plugins.copyright',
+    'sigal.plugins.extended_caching'
+    'sigal.plugins.feeds',
+    'sigal.plugins.nomedia',
+    'sigal.plugins.watermark',
+    'sigal.plugins.zip_gallery',
+]
 copyright = '© An example copyright message'
 adjust_options = {'color': 0.9, 'brightness': 1.0,
                   'contrast': 1.0, 'sharpness': 0.0}

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -8,13 +8,13 @@ from sigal.settings import read_settings
 
 CURRENT_DIR = os.path.dirname(__file__)
 SAMPLE_DIR = os.path.join(CURRENT_DIR, 'sample')
-SAMPLE_SOURCE = os.path.join(SAMPLE_DIR, 'pictures', 'dir1')
+SAMPLE_SOURCE = os.path.join(SAMPLE_DIR, 'pictures')
 
 
-def make_gallery(**kwargs):
+def make_gallery(source_dir='dir1', **kwargs):
     default_conf = os.path.join(SAMPLE_DIR, 'sigal.conf.py')
     settings = read_settings(default_conf)
-    settings['source'] = SAMPLE_SOURCE
+    settings['source'] = os.path.join(SAMPLE_SOURCE, source_dir)
     settings.update(kwargs)
     init_plugins(settings)
     return Gallery(settings, ncpu=1)
@@ -22,15 +22,13 @@ def make_gallery(**kwargs):
 
 def test_zipped_correctly(tmpdir):
     outpath = str(tmpdir)
-    gallery = make_gallery(destination=outpath,
-                           zip_gallery='archive.zip')
+    gallery = make_gallery(destination=outpath, zip_gallery='archive.zip')
     gallery.build()
 
-    zipped1 = glob.glob(os.path.join(outpath, 'test1', '*.zip'))
-    assert len(zipped1) == 1
-    assert os.path.basename(zipped1[0]) == 'archive.zip'
+    zipf = os.path.join(outpath, 'test1', 'archive.zip')
+    assert os.path.isfile(zipf)
 
-    zip_file = zipfile.ZipFile(zipped1[0], 'r')
+    zip_file = zipfile.ZipFile(zipf, 'r')
     expected = ('11.jpg', 'CMB_Timeline300_no_WMAP.jpg',
                 'flickr_jerquiaga_2394751088_cc-by-nc.jpg',
                 'example.gif')
@@ -40,16 +38,23 @@ def test_zipped_correctly(tmpdir):
 
     zip_file.close()
 
-    zipped2 = glob.glob(os.path.join(outpath, 'test2', '*.zip'))
-    assert len(zipped2) == 1
-    assert os.path.basename(zipped2[0]) == 'archive.zip'
+    assert os.path.isfile(os.path.join(outpath, 'test2', 'archive.zip'))
+
+
+def test_not_zipped(tmpdir):
+    # test that the zip file is not created when the .nozip_gallery file
+    # is present
+    outpath = str(tmpdir)
+    gallery = make_gallery(destination=outpath, zip_gallery='archive.zip',
+                           source_dir='dir2')
+    gallery.build()
+    assert not os.path.isfile(os.path.join(outpath, 'archive.zip'))
 
 
 def test_no_archive(tmpdir):
     outpath = str(tmpdir)
-    gallery = make_gallery(destination=outpath,
-                           zip_gallery=False)
+    gallery = make_gallery(destination=outpath, zip_gallery=False)
     gallery.build()
 
-    assert not glob.glob(os.path.join(outpath, 'test1', '*.zip'))
-    assert not glob.glob(os.path.join(outpath, 'test2', '*.zip'))
+    assert not os.path.isfile(os.path.join(outpath, 'test1', 'archive.zip'))
+    assert not os.path.isfile(os.path.join(outpath, 'test2', 'archive.zip'))

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -2,6 +2,7 @@ import os
 import glob
 import zipfile
 
+from sigal import init_plugins
 from sigal.gallery import Gallery
 from sigal.settings import read_settings
 
@@ -15,6 +16,7 @@ def make_gallery(**kwargs):
     settings = read_settings(default_conf)
     settings['source'] = SAMPLE_SOURCE
     settings.update(kwargs)
+    init_plugins(settings)
     return Gallery(settings, ncpu=1)
 
 


### PR DESCRIPTION
Heavily inspired by the `.nomedia` file, this patch introduces a new plugin called `nozip_gallery`.

If `zip_gallery` is _enabled_, this plugin allows to control on a per album basis if a ZIP file should be generated or not.

It currently uses a `.nozip_gallery` file (empty or not) to achieve such behavior.

The motivation behind this plugin is:
* disable ZIP file generation for my _very old_ photo albums
* enable ZIP file generation for my recent photo albums