### PR TITLE
Improve error message when template is not found

### DIFF
--- a/sigal/writer.py
+++ b/sigal/writer.py
@@ -87,8 +87,8 @@ class AbstractWriter(object):
         try:
             self.template = env.get_template(self.template_file)
         except TemplateNotFound:
-            self.logger.error('The template %s was not found.',
-                              self.template_file)
+            self.logger.error('The template %s was not found in template folder %s.',
+                              self.template_file, theme_relpath)
             sys.exit(1)
 
         # Copy the theme files in the output dir


### PR DESCRIPTION
The previous error message did not include the path that was
searched in. By including the path the debugging of the config
becomes way easiert (e.g. in my case I had added the '/templates'
folder which was added again by sigal).