### PR TITLE
Decode from utf-8 when using os.path.join

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -158,8 +158,8 @@ def build(source, destination, debug, verbose, quiet, force, config, theme,
 
     # copy extra files
     for src, dst in settings['files_to_copy']:
-        src = os.path.join(settings['source'], src)
-        dst = os.path.join(settings['destination'], dst)
+        src = os.path.join(settings['source'], src.decode('utf-8'))
+        dst = os.path.join(settings['destination'], dst.decode('utf-8'))
         logger.debug('Copy %s to %s', src, dst)
         copy(src, dst, symlink=settings['orig_link'], rellink=settings['rel_link'])
 


### PR DESCRIPTION
We may add UTF-8 encoded file names to the UTF-8 encoded
sigal.conf.py. Then, in order to use os.path.join, we need to decode
first or we may found ourselves with something like:

Traceback (most recent call last):
  File "/home/sigal/virtualenv/bin/sigal", line 9, in <module>
    load_entry_point('sigal==1.3.0', 'console_scripts', 'sigal')()
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/sigal/virtualenv/local/lib/python2.7/site-packages/sigal-1.3.0-py2.7.egg/sigal/__init__.py", line 147, in build
    src = os.path.join(settings['source'], src)
  File "/home/sigal/virtualenv/lib/python2.7/posixpath.py", line 73, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 40: ordinal not in range(128)