### PR TITLE
Add an option to process huge images

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ alphabetical order):
 - Christophe-Marie Duquesne
 - Craig Gallek
 - @datro
+- David Schultz
 - David Siroky
 - Edward Betts
 - Edwin Steele

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -52,6 +52,7 @@ _DEFAULT_CONFIG = {
     'links': '',
     'locale': '',
     'make_thumbs': True,
+    'max_img_pixels': None,
     'medias_sort_attr': 'filename',
     'medias_sort_reverse': False,
     'mp4_options': ['-crf', '23', '-strict', '-2'],

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -46,6 +46,11 @@ theme = 'galleria'
 # Size of resized image (default: (640, 480))
 img_size = (800, 600)
 
+# Max input image size in pixels (default: None, i.e. use PIL default)
+# This option sets `PIL.Image.MAX_IMAGE_PIXELS` in case you want to
+# convert/resize very large images.
+# max_img_pixels = None
+
 # Output format of images (default: None, i.e. use input format)
 # img_format = "JPEG"
 

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -292,7 +292,7 @@ def test_gallery(settings, tmpdir):
 
 def test_gallery_max_img_pixels(settings, tmpdir, monkeypatch):
     "Test the Gallery class with the max_img_pixels setting."
-    monkeypatch.setattr('PIL.Image.MAX_IMAGE_PIXELS', 100000000)
+    monkeypatch.setattr('PIL.Image.MAX_IMAGE_PIXELS', 100_000_000)
 
     with open(str(tmpdir.join('my.css')), mode='w') as f:
         f.write('color: red')
@@ -308,7 +308,7 @@ def test_gallery_max_img_pixels(settings, tmpdir, monkeypatch):
             gal = Gallery(settings, ncpu=1)
             gal.build()
 
-        settings['max_img_pixels'] = 100000000
+        settings['max_img_pixels'] = 100_000_000
         gal = Gallery(settings, ncpu=1)
         gal.build()
     finally:

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -292,6 +292,9 @@ def test_gallery(settings, tmpdir):
 
 def test_gallery_max_img_pixels(settings, tmpdir, monkeypatch):
     "Test the Gallery class with the max_img_pixels setting."
+    # monkeypatch is used here to reset the value to the PIL default.
+    # This value does not matter, other than it is "large"
+    # to show that settings['max_img_pixels'] works.
     monkeypatch.setattr('PIL.Image.MAX_IMAGE_PIXELS', 100_000_000)
 
     with open(str(tmpdir.join('my.css')), mode='w') as f:

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -4,6 +4,7 @@ import os
 from os.path import join
 
 import pytest
+from PIL import Image as PILImage
 
 from sigal.gallery import Album, Gallery, Image, Media, Video
 from sigal.video import SubprocessException
@@ -285,6 +286,31 @@ def test_gallery(settings, tmpdir):
         gal = Gallery(settings, ncpu=1)
         with pytest.raises(SubprocessException):
             gal.build()
+    finally:
+        logger.setLevel(logging.INFO)
+
+
+def test_gallery_max_img_pixels(settings, tmpdir, monkeypatch):
+    "Test the Gallery class with the max_img_pixels setting."
+    monkeypatch.setattr('PIL.Image.MAX_IMAGE_PIXELS', 100000000)
+
+    with open(str(tmpdir.join('my.css')), mode='w') as f:
+        f.write('color: red')
+
+    settings['destination'] = str(tmpdir)
+    settings['user_css'] = str(tmpdir.join('my.css'))
+    settings['max_img_pixels'] = 5000
+
+    logger = logging.getLogger('sigal')
+    logger.setLevel(logging.DEBUG)
+    try:
+        with pytest.raises(PILImage.DecompressionBombError):
+            gal = Gallery(settings, ncpu=1)
+            gal.build()
+
+        settings['max_img_pixels'] = 100000000
+        gal = Gallery(settings, ncpu=1)
+        gal.build()
     finally:
         logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
This PR adds an option to set `PIL.Image.MAX_IMAGE_PIXELS`, to enable huge image processing.

Fixes #332.