### PR TITLE
Sqlite cache for metadata lookup

### DIFF
--- a/sigal/__init__.py
+++ b/sigal/__init__.py
@@ -108,13 +108,15 @@ def init(path):
 )
 @option('--title', help="Title of the gallery (overrides the title setting.")
 @option('-n', '--ncpu', help="Number of cpu to use (default: all)")
+@option('--cache', help="Cache file path")
 def build(
-    source, destination, debug, verbose, quiet, force, config, theme, title, ncpu
+    source, destination, debug, verbose, quiet, force, config, theme, title,
+    ncpu, cache
 ):
     """Run sigal to process a directory.
 
-    If provided, 'source', 'destination' and 'theme' will override the
-    corresponding values from the settings file.
+    If provided, 'source', 'destination', 'theme' and 'cache' will override
+    the corresponding values from the settings file.
 
     """
     if sum([debug, verbose, quiet]) > 1:
@@ -139,7 +141,7 @@ def build(
     start_time = time.time()
     settings = read_settings(config)
 
-    for key in ('source', 'destination', 'theme'):
+    for key in ('source', 'destination', 'theme', 'cache'):
         arg = locals()[key]
         if arg is not None:
             settings[key] = os.path.abspath(arg)

--- a/sigal/cache.py
+++ b/sigal/cache.py
@@ -1,0 +1,102 @@
+from pickle import loads, dumps
+import logging
+import os
+from os.path import isfile
+import sqlite3
+
+from .utils import get_mod_date
+
+
+class Cache:
+    """
+    Uses sqlite3 to cache file data for faster lookup.
+
+    A cache is considered good if the file modification date is accurate
+    to the second.
+
+    Cache contents can either be a string or a dict (such as metadata).
+    """
+    def __init__(self, settings):
+        self.settings = settings
+        self.con = None
+        self.logger = logging.getLogger(__name__)
+
+    def __enter__(self):
+        if (not self.con) and self.settings.get('cache', None):
+            self.con = sqlite3.connect(':memory:')
+            if isfile(self.settings['cache']):
+                self.logger.info('Loading cache from file %s',
+                                 self.settings['cache'])
+                try:
+                    disk_con = sqlite3.connect(self.settings['cache'])
+                    with self.con:
+                        disk_con.backup(self.con)
+                    disk_con.close()
+                except sqlite3.OperationalError:
+                    self.logger.warning('Cache db is corrupt, deleting')
+                    os.remove(self.settings['cache'])
+
+            sql = ('CREATE TABLE IF NOT EXISTS '
+                   'cache(path NOT NULL PRIMARY KEY, mod, data)')
+            self.con.execute(sql)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.con:
+            return
+
+        if (not exc_type) and self.settings.get('cache', None):
+            self.logger.info('Saving cache to file %s',
+                             self.settings['cache'])
+            disk_con = sqlite3.connect(self.settings['cache'])
+            with disk_con:
+                self.con.backup(disk_con)
+            disk_con.close()
+        self.con.close()
+        self.con = None
+
+    def read(self, path):
+        if not self.con:
+            return None
+
+        self.logger.debug('Reading from cache: %s', path)
+
+        mod_date = int(get_mod_date(path))
+
+        cur = self.con.execute('SELECT mod,data FROM cache WHERE path = ?',
+                               (path, ))
+        row = cur.fetchone()
+
+        if row and mod_date == row[0]:
+            return row[1]
+        else:
+            return None
+
+    def read_dict(self, path):
+        if not self.con:
+            return None
+
+        data = self.read(path)
+        if data:
+            return loads(data)
+        else:
+            return None
+
+    def write(self, path, data):
+        if not self.con:
+            return
+
+        self.logger.debug('Writing to cache: %s', path)
+
+        mod_date = int(get_mod_date(path))
+
+        self.con.execute('REPLACE INTO cache (path, mod, data) VALUES (?, ?, ?)',
+                         (path, mod_date, data))
+        self.con.commit()
+
+    def write_dict(self, path, data):
+        if not self.con:
+            return
+
+        self.write(path, dumps(data))

--- a/sigal/settings.py
+++ b/sigal/settings.py
@@ -30,6 +30,7 @@ _DEFAULT_CONFIG = {
     'albums_sort_attr': 'name',
     'albums_sort_reverse': False,
     'autorotate_images': True,
+    'cache': None,
     'colorbox_column_size': 3,
     'copy_exif_data': False,
     'datetime_format': '%c',

--- a/sigal/templates/sigal.conf.py
+++ b/sigal/templates/sigal.conf.py
@@ -19,6 +19,10 @@ source = 'pictures'
 # `sigal build` command (default: '_build')
 # destination = '_build'
 
+# Cache file. Can be set here or as an argument to the `sigal build` command.
+# Uses sqlite3 to cache markdown contents for faster re-processing.
+# cache = None
+
 # Theme :
 # - colorbox (default), galleria, photoswipe, or the path to a custom theme
 # directory

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from functools import lru_cache
 import os
 import shutil
 from urllib.parse import quote
@@ -62,6 +63,12 @@ def check_or_create_dir(path):
 
     if not os.path.isdir(path):
         os.makedirs(path)
+
+
+@lru_cache(maxsize=1024)
+def get_mod_date(path):
+    """Get modification date for a path, caching result with LRU cache."""
+    return os.path.getmtime(path)
 
 
 def url_from_path(path):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,94 @@
+import os
+
+from sigal.utils import read_markdown
+from sigal.cache import Cache
+
+
+CURRENT_DIR = os.path.dirname(__file__)
+SAMPLE_DIR = os.path.join(CURRENT_DIR, 'sample')
+TEST_META = os.path.join(SAMPLE_DIR, 'pictures/dir1/test1/11.md')
+
+
+def test_no_cache(tmpdir):
+    data = 'testing'
+    with Cache({}) as c:
+        assert c.read(TEST_META) is None
+        c.write(TEST_META, data)
+        assert c.read(TEST_META) is None
+
+    data = {'test': True}
+    with Cache({}) as c:
+        assert c.read_dict(TEST_META) is None
+        c.write_dict(TEST_META, data)
+        assert c.read_dict(TEST_META) is None
+
+
+def test_cache(tmpdir):
+    settings = {'cache': os.path.join(tmpdir, 'cache.sqlite')}
+    data = 'testing'
+    with Cache(settings) as c:
+        assert c.read(TEST_META) is None
+        c.write(TEST_META, data)
+        assert c.read(TEST_META) == data
+
+    assert os.path.isfile(settings['cache'])
+
+    with Cache(settings) as c:
+        assert c.read(TEST_META) == data
+
+
+def test_cache_dict(tmpdir):
+    settings = {'cache': os.path.join(tmpdir, 'cache.sqlite')}
+    data = read_markdown(TEST_META)
+    with Cache(settings) as c:
+        assert c.read_dict(TEST_META) is None
+        c.write_dict(TEST_META, data)
+        assert c.read_dict(TEST_META) == data
+
+    assert os.path.isfile(settings['cache'])
+
+    with Cache(settings) as c:
+        assert c.read_dict(TEST_META) == data
+
+
+def test_invalid_cache(tmpdir):
+    """
+    Test an invalid cache file.
+    Should delete bad file and continue.
+    """
+    settings = {'cache': os.path.join(tmpdir, 'cache.sqlite')}
+    with open(settings['cache'], 'w') as f:
+        f.write('invalid')
+
+    data = 'testing'
+    with Cache(settings) as c:
+        assert c.read(TEST_META) is None
+        c.write(TEST_META, data)
+        assert c.read(TEST_META) == data
+
+    assert os.path.isfile(settings['cache'])
+
+    with Cache(settings) as c:
+        assert c.read(TEST_META) == data
+
+
+def test_cache_exception(tmpdir):
+    """
+    Test what happens when an exception occurs.
+    Cache should not be saved.
+    """
+    settings = {'cache': os.path.join(tmpdir, 'cache.sqlite')}
+    data = 'testing'
+    try:
+        with Cache(settings) as c:
+            assert c.read(TEST_META) is None
+            c.write(TEST_META, data)
+            assert c.read(TEST_META) == data
+            raise RuntimeError()
+    except RuntimeError:
+        pass
+
+    assert not os.path.isfile(settings['cache'])
+
+    with Cache(settings) as c:
+        assert c.read(TEST_META) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from time import sleep
 
 from sigal import utils
 
@@ -48,6 +49,20 @@ def test_check_or_create_dir(tmpdir):
     path = str(tmpdir.join('new_directory'))
     utils.check_or_create_dir(path)
     assert os.path.isdir(path)
+
+
+def test_get_mod_date(tmp_path):
+    path = tmp_path / 'foo'
+    path.touch()
+    start = utils.get_mod_date(str(path))
+    sleep(.1)
+    path.touch()
+    end = utils.get_mod_date(str(path))
+    assert start == end  # cache is working
+
+    utils.get_mod_date.cache_clear()
+    end = utils.get_mod_date(str(path))
+    assert start != end
 
 
 def test_url_from_path():


### PR DESCRIPTION
Add an optional sqlite cache for metadata lookup, instead of opening md or image files (for exif data). This greatly speeds up rebuilding for large libraries.  The cache does check the file modification time, so will allow updates.

As an example, I have ~50k files in a library, and this cache reduces the time by half when running updates.