### PR TITLE
Extend caching plugin to handle markdown and iptc metadata

### DIFF
--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -188,33 +188,33 @@ class Media:
     @cached_property
     def description(self):
         """Description extracted from the Markdown <imagename>.md file."""
-        return self.raw_metadata.get('description', '')
+        return self.markdown_metadata.get('description', '')
 
     @cached_property
     def title(self):
         """Title extracted from the metadata, or defaults to the filename."""
-        title = self.raw_metadata.get('title', '')
+        title = self.markdown_metadata.get('title', '')
         return title if title else self.basename
 
     @cached_property
     def meta(self):
         """Other metadata extracted from the Markdown <imagename>.md file."""
-        return self.raw_metadata.get('meta', {})
+        return self.markdown_metadata.get('meta', {})
 
     @cached_property
-    def raw_metadata(self):
+    def markdown_metadata(self):
         """Get metadata from filename.md: title, description, meta."""
-        return self._get_raw_metadata()
+        return self._get_markdown_metadata()
 
     @property
-    def raw_metadata_filepath(self):
+    def markdown_metadata_filepath(self):
         return splitext(self.src_path)[0] + '.md'
 
-    def _get_raw_metadata(self):
+    def _get_markdown_metadata(self):
         """Get metadata from filename.md."""
         meta = {'title': '', 'description': '', 'meta': {}}
-        if isfile(self.raw_metadata_filepath):
-            meta.update(read_markdown(self.raw_metadata_filepath))
+        if isfile(self.markdown_metadata_filepath):
+            meta.update(read_markdown(self.markdown_metadata_filepath))
         return meta
 
     @cached_property
@@ -265,9 +265,9 @@ class Image(Media):
         """Image file metadata (Exif and IPTC)"""
         return get_image_metadata(self.src_path)
 
-    def _get_raw_metadata(self):
+    def _get_markdown_metadata(self):
         """Get metadata from filename.md."""
-        meta = super()._get_raw_metadata()
+        meta = super()._get_markdown_metadata()
 
         # If a title or description hasn't been obtained by other means, look
         #  for the information in IPTC fields
@@ -428,19 +428,19 @@ class Album:
     @cached_property
     def description(self):
         """Description extracted from the Markdown index.md file."""
-        return self.raw_metadata.get('description', '')
+        return self.markdown_metadata.get('description', '')
 
     @cached_property
     def title(self):
         """Title extracted from the Markdown index.md file."""
-        title = self.raw_metadata.get('title', '')
+        title = self.markdown_metadata.get('title', '')
         path = self.path if self.path != '.' else self.src_path
         return title if title else os.path.basename(path)
 
     @cached_property
     def meta(self):
         """Other metadata extracted from the Markdown index.md file."""
-        return self.raw_metadata.get('meta', {})
+        return self.markdown_metadata.get('meta', {})
 
     @cached_property
     def author(self):
@@ -451,15 +451,15 @@ class Album:
             return self.settings.get('author')
 
     @property
-    def raw_metadata_filepath(self):
+    def markdown_metadata_filepath(self):
         return join(self.src_path, self.description_file)
 
     @cached_property
-    def raw_metadata(self):
+    def markdown_metadata(self):
         """Get metadata from filename.md: title, description, meta."""
         meta = {'title': '', 'description': '', 'meta': {}}
-        if isfile(self.raw_metadata_filepath):
-            meta.update(read_markdown(self.raw_metadata_filepath))
+        if isfile(self.markdown_metadata_filepath):
+            meta.update(read_markdown(self.markdown_metadata_filepath))
         return meta
 
     def create_output_directories(self):

--- a/sigal/plugins/extended_caching.py
+++ b/sigal/plugins/extended_caching.py
@@ -51,14 +51,14 @@ def load_metadata(album):
 
         # check if file has changed
         try:
-            mod_date = int(get_mod_date(album.raw_metadata_filepath))
+            mod_date = int(get_mod_date(album.markdown_metadata_filepath))
         except FileNotFoundError:
             pass
         else:
             if data.get('mod_date', -1) >= mod_date:
                 # cache is good
-                if 'raw_metadata' in data:
-                    album.raw_metadata = data['raw_metadata']
+                if 'markdown_metadata' in data:
+                    album.markdown_metadata = data['markdown_metadata']
 
     # load media metadata
     for media in album.medias:
@@ -80,14 +80,14 @@ def load_metadata(album):
                 media.exif = data['exif']
 
             try:
-                mod_date = int(get_mod_date(media.raw_metadata_filepath))
+                mod_date = int(get_mod_date(media.markdown_metadata_filepath))
             except FileNotFoundError:
                 continue
             if data.get('meta_mod_date', -1) < mod_date:
-                continue  # raw_metadata needs updating
+                continue  # markdown_metadata needs updating
 
-            if 'raw_metadata' in data:
-                media.raw_metadata = data['raw_metadata']
+            if 'markdown_metadata' in data:
+                media.markdown_metadata = data['markdown_metadata']
 
 
 def _restore_cache(gallery):
@@ -116,8 +116,8 @@ def save_cache(gallery):
     for album in gallery.albums.values():
         try:
             data = {
-                'mod_date': int(get_mod_date(album.raw_metadata_filepath)),
-                'raw_metadata': album.raw_metadata,
+                'mod_date': int(get_mod_date(album.markdown_metadata_filepath)),
+                'markdown_metadata': album.markdown_metadata,
             }
             cache[os.path.join(album.path, '_index')] = data
         except FileNotFoundError:
@@ -136,12 +136,12 @@ def save_cache(gallery):
                     data['exif'] = media.exif
 
             try:
-                meta_mod_date = int(get_mod_date(media.raw_metadata_filepath))
+                meta_mod_date = int(get_mod_date(media.markdown_metadata_filepath))
             except FileNotFoundError:
                 pass
             else:
                 data['meta_mod_date'] = meta_mod_date
-                data['raw_metadata'] = media.raw_metadata
+                data['markdown_metadata'] = media.markdown_metadata
 
             cache[os.path.join(media.path, media.dst_filename)] = data
 

--- a/sigal/plugins/extended_caching.py
+++ b/sigal/plugins/extended_caching.py
@@ -101,7 +101,7 @@ def _restore_cache(gallery):
         else:
             gallery.metadataCache = {}
     except Exception as e:
-        logger.warn("Could not load cache: %s", e)
+        logger.warning("Could not load cache: %s", e)
         gallery.metadataCache = {}
 
 

--- a/sigal/utils.py
+++ b/sigal/utils.py
@@ -18,6 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from functools import lru_cache
 import os
 import shutil
 from urllib.parse import quote
@@ -62,6 +63,12 @@ def check_or_create_dir(path):
 
     if not os.path.isdir(path):
         os.makedirs(path)
+
+
+@lru_cache(maxsize=1024)
+def get_mod_date(path):
+    """Get modification date for a path, caching result with LRU cache."""
+    return os.path.getmtime(path)
 
 
 def url_from_path(path):

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -16,6 +16,7 @@ files_to_copy = (("../watermark.png", "watermark.png"),)
 plugins = [
     "sigal.plugins.adjust",
     "sigal.plugins.copyright",
+    "sigal.plugins.extended_caching",
     "sigal.plugins.feeds",
     "sigal.plugins.nomedia",
     "sigal.plugins.watermark",

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -16,7 +16,6 @@ files_to_copy = (("../watermark.png", "watermark.png"),)
 plugins = [
     "sigal.plugins.adjust",
     "sigal.plugins.copyright",
-    "sigal.plugins.extended_caching",
     "sigal.plugins.feeds",
     "sigal.plugins.nomedia",
     "sigal.plugins.watermark",

--- a/tests/test_extended_caching.py
+++ b/tests/test_extended_caching.py
@@ -8,6 +8,7 @@ CURRENT_DIR = os.path.dirname(__file__)
 
 
 def test_save_cache(settings, tmpdir):
+    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal = Gallery(settings, ncpu=1)
     extended_caching.save_cache(gal)
@@ -23,32 +24,33 @@ def test_save_cache(settings, tmpdir):
     album = gal.albums["exifTest"]
     cache_img = cache["exifTest/21.jpg"]
     assert cache_img["exif"] == album.medias[0].exif
-    assert 'raw_metadata' not in cache_img
+    assert 'markdown_metadata' not in cache_img
     assert cache_img["file_metadata"] == album.medias[0].file_metadata
 
     cache_img = cache["exifTest/22.jpg"]
     assert cache_img["exif"] == album.medias[1].exif
-    assert 'raw_metadata' not in cache_img
+    assert 'markdown_metadata' not in cache_img
     assert cache_img["file_metadata"] == album.medias[1].file_metadata
 
     cache_img = cache["exifTest/noexif.png"]
     assert cache_img["exif"] == album.medias[2].exif
-    assert 'raw_metadata' not in cache_img
+    assert 'markdown_metadata' not in cache_img
     assert cache_img["file_metadata"] == album.medias[2].file_metadata
 
     # test iptc and md
     album = gal.albums["iptcTest"]
-    assert cache["iptcTest/_index"]["raw_metadata"] == album.raw_metadata
+    assert cache["iptcTest/_index"]["markdown_metadata"] == album.markdown_metadata
 
     cache_img = cache["iptcTest/1.jpg"]
     assert cache_img["file_metadata"] == album.medias[0].file_metadata
-    assert 'raw_metadata' not in cache_img
+    assert 'markdown_metadata' not in cache_img
 
     cache_img = cache["iptcTest/2.jpg"]
-    assert cache_img["raw_metadata"] == album.medias[1].raw_metadata
+    assert cache_img["markdown_metadata"] == album.medias[1].markdown_metadata
 
 
 def test_restore_cache(settings, tmpdir):
+    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal1 = Gallery(settings, ncpu=1)
     gal2 = Gallery(settings, ncpu=1)
@@ -58,6 +60,7 @@ def test_restore_cache(settings, tmpdir):
 
 
 def test_load_exif(settings, tmpdir):
+    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal1 = Gallery(settings, ncpu=1)
     gal1.albums["exifTest"].medias[2].exif = "blafoo"

--- a/tests/test_extended_caching.py
+++ b/tests/test_extended_caching.py
@@ -8,7 +8,6 @@ CURRENT_DIR = os.path.dirname(__file__)
 
 
 def test_save_cache(settings, tmpdir):
-    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal = Gallery(settings, ncpu=1)
     extended_caching.save_cache(gal)
@@ -50,7 +49,6 @@ def test_save_cache(settings, tmpdir):
 
 
 def test_restore_cache(settings, tmpdir):
-    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal1 = Gallery(settings, ncpu=1)
     gal2 = Gallery(settings, ncpu=1)
@@ -60,7 +58,6 @@ def test_restore_cache(settings, tmpdir):
 
 
 def test_load_exif(settings, tmpdir):
-    settings['plugins'].append('sigal.plugins.extended_caching')
     settings['destination'] = str(tmpdir)
     gal1 = Gallery(settings, ncpu=1)
     gal1.albums["exifTest"].medias[2].exif = "blafoo"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -242,7 +242,8 @@ def test_get_iptc_data(caplog):
         assert ['IPTC Error in'] == [log.message[:13] for log in caplog.records]
 
 
-def test_get_image_metadata_bad(caplog):
+def test_get_image_metadata_exceptions():
+    # image does not exist
     test_image = 'bad_image.jpg'
     src_file = os.path.join(CURRENT_DIR, 'sample', test_image)
     data = get_image_metadata(src_file)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -12,6 +12,7 @@ from sigal.image import (
     get_exif_data,
     get_exif_tags,
     get_iptc_data,
+    get_image_metadata,
     get_size,
     process_image,
 )
@@ -239,6 +240,13 @@ def test_get_iptc_data(caplog):
     with patch('sigal.image.IptcImagePlugin.getiptcinfo', side_effect=SyntaxError):
         get_iptc_data(src_file)
         assert ['IPTC Error in'] == [log.message[:13] for log in caplog.records]
+
+
+def test_get_image_metadata_bad(caplog):
+    test_image = 'bad_image.jpg'
+    src_file = os.path.join(CURRENT_DIR, 'sample', test_image)
+    data = get_image_metadata(src_file)
+    assert data == {'exif': {}, 'iptc': {}, 'size': {}}
 
 
 def test_iso_speed_ratings():


### PR DESCRIPTION
Turn markdown metadata in `gallery.py` into a property so it can be overridden.
Extend the caching plugin to handle markdown and iptc metadata (previously only handled exif).
Invalidate cache when a file timestamp changes, so we always get the latest data.
Cache file modification time lookups within a build to reduce load on filesystem.

Supersedes #440.