### PR TITLE
Add original size information for 'Download ZIP' link in album

### DIFF
--- a/sigal/themes/colorbox/templates/album.html
+++ b/sigal/themes/colorbox/templates/album.html
@@ -61,10 +61,17 @@
   </div>
 
   {% if album.zip %}
-  <div id="additionnal-infos" class="row">
-    <p><a href="{{ album.zip }}"
-        title="Download a zip archive with all images">Download ZIP</a></p>
-  </div>
+    {% if album.settings['zip_media_format'] == "orig" %}
+      <div id="additionnal-infos" class="row">
+        <p><a href="{{ album.zip }}"
+              title="Download a zip archive with all images original size">Download ZIP with original files</a></p>
+      </div>
+    {% else %}
+      <div id="additionnal-infos" class="row">
+        <p><a href="{{ album.zip }}"
+              title="Download a zip archive with all images">Download ZIP</a></p>
+      </div>
+    {% endif %}
   {% endif %}
 
 {% endblock %}

--- a/sigal/themes/galleria/templates/album_items.html
+++ b/sigal/themes/galleria/templates/album_items.html
@@ -9,11 +9,17 @@
         <div id="gallery"></div>
 
         {% if album.zip %}
-        <div id="additionnal-infos" class="row">
-          <p><a href="{{ album.zip }}"
-                title="Download a zip archive with all images">Download ZIP</a>
-          </p>
-        </div>
+          {% if album.settings['zip_media_format'] == "orig" %}
+            <div id="additionnal-infos" class="row">
+              <p><a href="{{ album.zip }}"
+                    title="Download a zip archive with all images original size">Download ZIP with original files</a></p>
+            </div>
+          {% else %}
+            <div id="additionnal-infos" class="row">
+              <p><a href="{{ album.zip }}"
+                    title="Download a zip archive with all images">Download ZIP</a></p>
+            </div>
+          {% endif %}
         {% endif %}
 
         {% if album.description %}

--- a/sigal/themes/photoswipe/templates/album.html
+++ b/sigal/themes/photoswipe/templates/album.html
@@ -10,10 +10,17 @@
 
 {% block content %}
   {% if album.zip %}
-  <div class="additionnal-infos">
-    <p><a href="{{ album.zip }}"
-          title="Download a zip archive with all images">Download ZIP</a></p>
-  </div>
+    {% if album.settings['zip_media_format'] == "orig" %}
+      <div class="additionnal-infos">
+        <p><a href="{{ album.zip }}"
+              title="Download a zip archive with all images original size">Download ZIP with original files</a></p>
+      </div>
+    {% else %}
+      <div class="additionnal-infos">
+        <p><a href="{{ album.zip }}"
+              title="Download a zip archive with all images">Download ZIP</a></p>
+      </div>
+    {% endif %}
   {% endif %}
 
   <div class="gallery" itemscope itemtype="http://schema.org/ImageGallery">


### PR DESCRIPTION
For all themes (colorbox, galleria, photoswipe), modified "Download ZIP" link to "Download ZIP with original files" if zip archive was created with original files.