### PR TITLE
List of sort-properties as fallback instead of zero-length string

### DIFF
--- a/sigal/gallery.py
+++ b/sigal/gallery.py
@@ -488,18 +488,26 @@ class Album:
                     reverse = False
 
             root_path = self.path if self.path != '.' else ''
-            if albums_sort_attr.startswith("meta."):
-                meta_key = albums_sort_attr.split(".", 1)[1]
 
-                def sort_key(s):
-                    album = self.gallery.albums[join(root_path, s)]
-                    return album.meta.get(meta_key, [''])[0]
+            def sort_key(s):
+                sort_attr = albums_sort_attr
+                if not isinstance(sort_attr,list):
+                    sort_attr = [sort_attr] 
 
-            else:
+                album = self.gallery.albums[join(root_path, s)]
 
-                def sort_key(s):
-                    album = self.gallery.albums[join(root_path, s)]
-                    return getattr(album, albums_sort_attr)
+                for k in sort_attr:
+                    try:
+                        if k.startswith("meta."):
+                            meta_key = k.split(".", 1)[1]
+                            return album.meta.get(meta_key)[0]
+                        else:
+                            return getattr(album, k)
+                    except AttributeError:
+                        continue
+                    except TypeError:
+                        continue
+                return ''
 
             key = natsort_keygen(key=sort_key, alg=ns.LOCALE)
             self.subdirs.sort(key=key, reverse=reverse)

--- a/tests/sample/pictures/dir1/test1/index.md
+++ b/tests/sample/pictures/dir1/test1/index.md
@@ -1,3 +1,5 @@
 Title: An example sub-category
 Thumbnail: 11.jpg
 Order: 03
+PartialOrder: 00
+PartialOrderB: test4

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -11,6 +11,8 @@ links = [
     ("Another link", "http://example.org"),
 ]
 
+albums_sort_attr = [ "meta.nokey", "nosuchattribute", "name" ]
+
 files_to_copy = (("../watermark.png", "watermark.png"),)
 
 plugins = [

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -247,6 +247,21 @@ def test_albums_sort(settings):
     a.sort_subdirs('meta.order')
     assert [d.meta['order'][0] for d in a.albums] == list(reversed(orders))
 
+    settings['albums_sort_reverse'] = False
+    a = Album('dir1', settings, album['subdirs'], album['medias'], gal)
+    a.sort_subdirs(['meta.partialorder','meta.order'])
+    assert [d.name for d in a.albums] == list(['test1','test2','test3'])
+
+    settings['albums_sort_reverse'] = False
+    a = Album('dir1', settings, album['subdirs'], album['medias'], gal)
+    a.sort_subdirs(['meta.partialorderb','name'])
+    assert [d.name for d in a.albums] == list(['test2','test3','test1'])
+
+    settings['albums_sort_reverse'] = True
+    a = Album('dir1', settings, album['subdirs'], album['medias'], gal)
+    a.sort_subdirs(['meta.partialorderb','name'])
+    assert [d.name for d in a.albums] == list(['test1','test3','test2'])
+
 
 def test_medias_sort(settings):
     gal = Gallery(settings, ncpu=1)


### PR DESCRIPTION
This PR contains code to be able to replace the scalar 'albums_sort_attr' by a list of properties to take into account as keys for sorting.

Thus you may have multiple 'fallback' options for sorting and prevent unpredictable outcome of natsort, which previously was fed with a zero-length string for all items who did not offer the specified property. E.g. `albums_sort_attr = ['meta.sortname','filename']` would take the filename for those items who do not have `meta.sortname` available.