### PR TITLE
Another plugin: Titleregexp - modify titles of albums with regular expressions

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -145,3 +145,8 @@ ZIP Gallery plugin
 ==================
 
 .. automodule:: sigal.plugins.zip_gallery
+
+Titleregexp plugin
+==================
+
+.. automodule:: sigal.plugins.titleregexp

--- a/sigal/plugins/titleregexp.py
+++ b/sigal/plugins/titleregexp.py
@@ -1,0 +1,85 @@
+# Copyright 2022 - C.Sehrt
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+""" This plugin modifies titles of galleries by using regular-expressions and
+simple character replacements.
+
+Settings:
+
+- ``titleregexp`` with the following keys:
+    - ``regexp``, which is an array of dicts with 'search', 'replace' and 
+        'count' keys
+    - ``substitute``, which is an array of 2-element-arrays, of which the
+        second element denotes the replacement of occurences of the first 
+        element
+
+Example::
+
+    titleregexp = {
+        'regexp' : [
+            { 'search': r"^([0-9]*)-(.*)$", 'replace': r"\2 (\1)", 'count': 1 },
+            { 'search': r"([a-z][a-z])([A-Z][a-z])", 'replace': r"\1 \2" }
+            ],
+        'substitute' : [ [ '_', ' ' ] ]
+    }
+
+"""
+
+import logging
+import os
+import re
+
+from sigal import signals
+
+logger = logging.getLogger(__name__)
+cfg = {}
+
+def titleregexp(album):
+    """Create a title by regexping name"""
+    #logger.info("DEBUG: name=%s, path=%s, title=%s", album.name, album.path, album.title)
+    #print(dir(album))
+
+    cfg = album.settings.get('titleregexp')
+
+    n = 0
+    total = 0
+
+    for r in cfg.get('regexp') :
+        album.title, n = re.subn(r.get('search'), r.get('replace'), album.title, r.get('count', 0))
+        total += n
+
+        if n>0 :
+            for s in r.get('substitute', []) :
+                album.title = album.title.replace(r[0],r[1])
+            if r.get('break','') != '' :
+                break
+
+    for r in cfg.get('substitute', []) :
+        album.title = album.title.replace(r[0],r[1])
+
+    if total > 0:
+        logger.info("Fixing title to '%s'", album.title)
+
+
+def register(settings):
+    if settings.get('titleregexp'):
+        signals.album_initialized.connect(titleregexp)
+    else:
+        logger.warning("'titleregexp' setting not available!")

--- a/sigal/plugins/titleregexp.py
+++ b/sigal/plugins/titleregexp.py
@@ -67,7 +67,7 @@ def titleregexp(album):
 
         if n>0 :
             for s in r.get('substitute', []) :
-                album.title = album.title.replace(r[0],r[1])
+                album.title = album.title.replace(s[0],s[1])
             if r.get('break','') != '' :
                 break
 

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -21,6 +21,7 @@ plugins = [
     "sigal.plugins.nomedia",
     "sigal.plugins.watermark",
     "sigal.plugins.zip_gallery",
+    "sigal.plugins.titleregexp",
 ]
 copyright = "© An example copyright message"
 adjust_options = {
@@ -38,6 +39,12 @@ thumb_size = (200, 150)
 
 rss_feed = {"feed_url": "http://127.0.0.1:8000/feed.rss", "nb_items": 10}
 atom_feed = {"feed_url": "http://127.0.0.1:8000/feed.atom", "nb_items": 10}
+
+titleregexp = {
+    "regexp": [
+        { "search": r"test ?(.*)", "replace": r"titleregexp \1" }
+    ]
+}
 
 # theme = 'photoswipe'
 # theme = 'galleria'

--- a/tests/sample/sigal.conf.py
+++ b/tests/sample/sigal.conf.py
@@ -42,7 +42,7 @@ atom_feed = {"feed_url": "http://127.0.0.1:8000/feed.atom", "nb_items": 10}
 
 titleregexp = {
     "regexp": [
-        { "search": r"test ?(.*)", "replace": r"titleregexp \1" }
+        { "search": r"test ?(.*)", "replace": r"titleregexp \1", "substitute": [ [ "2", "02" ] ], "break": 1 }
     ]
 }
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -57,4 +57,4 @@ def test_titleregexp(settings, tmpdir, disconnect_signals):
     gal = Gallery(settings)
     gal.build()
 
-    assert gal.albums.get('dir1').albums[1].title == "titleregexp 2"
+    assert gal.albums.get('dir1').albums[1].title == "titleregexp 02"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -47,3 +47,14 @@ def test_nonmedia_files(settings, tmpdir, disconnect_signals):
         settings['destination'], 'nonmedia_files', 'thumbnails', 'dummy.tn.jpg'
     )
     assert os.path.isfile(outthumb)
+
+def test_titleregexp(settings, tmpdir, disconnect_signals):
+
+    if "sigal.plugins.titleregexp" not in settings["plugins"]:
+        settings['plugins'] += ["sigal.plugins.titleregexp"]
+
+    init_plugins(settings)
+    gal = Gallery(settings)
+    gal.build()
+
+    assert gal.albums.get('dir1').albums[1].title == "titleregexp 2"


### PR DESCRIPTION
This PR adds a plugin called 'titleregexp' which modifies titles of albums by configured regular expressions and simple search-and-replace tuples.