### PR TITLE
Added support for -a, --force-album argument

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -67,7 +67,7 @@ Optional arguments:
     -a 'My Pictures/*Pics'
             My Pictures/Old Pics => Force
             My Pictures/New Pics => Force
-            My Pictures/My Pics => No Force
+            My Pictures/Pictures => No Force
     -a 'Landscapes'
             My Pictures/Landscapes => Force
             My Other Pictures/Landscapes => Force

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -18,7 +18,7 @@ Build
   a sub-directory and run ``sigal build <your images directory>``.
 
   The next time you run ``sigal build``, only the new images will be processed.
-  You can use the ``-f`` flag to force the reprocessing of all the images.
+  You can use the ``-f`` flag to force the reprocessing of all the images or the ``-a`` flag to force only the specified matching albums.
   Images (resp. videos) that are smaller than the size specified by the
   ``img_size`` (resp. ``video_size``) setting will not be resized.
 
@@ -39,7 +39,7 @@ Help on the ``sigal build`` command
 
 ::
 
-    $ sigal build [-h] [-d] [-v] [-f] [-c CONFIG] [-t THEME] [-n NCPU]
+    $ sigal build [-h] [-d] [-v] [-f] [-a PATTERN] [-c CONFIG] [-t THEME] [-n NCPU]
             [source] [destination]
 
 Required arguments:
@@ -57,6 +57,20 @@ Optional arguments:
 
 ``-f, --force``
   Force the reprocessing of existing images and thumbnails
+
+``-a --force-album``
+  Force the reprocessing of existing images matching the given album wildcard pattern.
+  Patterns containing wildcards will be matched against the full album path, while patterns without wildcards will be match against the album name only:
+
+::
+
+    -a 'My Pictures/*Pics'
+            My Pictures/Old Pics => Force
+            My Pictures/New Pics => Force
+            My Pictures/My Pics => No Force
+    -a 'Landscapes'
+            My Pictures/Landscapes => Force
+            My Other Pictures/Landscapes => Force
 
 ``-v, --verbose``
   Show all messages

--- a/src/sigal/__init__.py
+++ b/src/sigal/__init__.py
@@ -78,6 +78,7 @@ def init(path):
 @argument("source", required=False)
 @argument("destination", required=False)
 @option("-f", "--force", is_flag=True, help="Force the reprocessing of existing images")
+@option("-a", "--force-album", multiple=True, help="Force reprocessing of any album that matches the given pattern. Patterns containing no wildcards will be matched against only the album name. (-a 'My Pictures/* Pics' -a 'Festival')")
 @option("-v", "--verbose", is_flag=True, help="Show all messages")
 @option(
     "-d",
@@ -106,7 +107,7 @@ def init(path):
 @option("--title", help="Title of the gallery (overrides the title setting.")
 @option("-n", "--ncpu", help="Number of cpu to use (default: all)")
 def build(
-    source, destination, debug, verbose, quiet, force, config, theme, title, ncpu
+    source, destination, debug, verbose, quiet, force, force_album, config, theme, title, ncpu
 ):
     """Run sigal to process a directory.
 
@@ -168,7 +169,7 @@ def build(
     init_plugins(settings)
 
     gal = Gallery(settings, ncpu=ncpu, quiet=quiet)
-    gal.build(force=force)
+    gal.build(force=force_album if len(force_album) else force)
 
     # copy extra files
     for src, dst in settings["files_to_copy"]:

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -38,7 +38,6 @@ from itertools import cycle
 from os.path import isfile, join, splitext
 from shutil import get_terminal_size
 from urllib.parse import quote as url_quote
-from fnmatch import fnmatch
 
 from click import progressbar
 from natsort import natsort_keygen, ns
@@ -938,7 +937,7 @@ class Gallery:
     def process_dir(self, album, force=False):
         """Process a list of images in a directory."""
         for f in album:
-            if isfile(f.dst_path) and not should_reprocess_album(a.path, a.name, force):
+            if isfile(f.dst_path) and not should_reprocess_album(album.path, album.name, force):
                 self.logger.info("%s exists - skipping", f.dst_filename)
                 self.stats[f.type + "_skipped"] += 1
             else:

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -56,6 +56,7 @@ from .utils import (
     is_valid_html5_video,
     read_markdown,
     url_from_path,
+    should_reprocess_album,
 )
 from .video import process_video
 from .writer import AlbumListPageWriter, AlbumPageWriter
@@ -824,7 +825,7 @@ class Gallery:
             for subname, album in self.get_albums(subdir):
                 yield subname, self.albums[subdir]
 
-    def build(self, force=None):
+    def build(self, force=False):
         "Create the image gallery"
 
         if not self.albums:
@@ -936,23 +937,8 @@ class Gallery:
 
     def process_dir(self, album, force=False):
         """Process a list of images in a directory."""
-        def forcing(a):
-            if force is None:
-                return False
-            if isinstance(force, bool):
-                return force
-            elif len(force) == 0:
-                return True
-            else:
-                for f in force:
-                    if '*' in f or '?' in f:
-                        if fnmatch(a.path, f):
-                            return True
-                    elif a.name == f:
-                        return True
-
         for f in album:
-            if isfile(f.dst_path) and not forcing(album):
+            if isfile(f.dst_path) and not should_reprocess_album(a.path, a.name, force):
                 self.logger.info("%s exists - skipping", f.dst_filename)
                 self.stats[f.type + "_skipped"] += 1
             else:

--- a/src/sigal/utils.py
+++ b/src/sigal/utils.py
@@ -81,6 +81,17 @@ def url_from_path(path):
         path = "/".join(path.split(os.sep))
     return quote(path)
 
+def should_reprocess_album(path, name, force=False):
+    if isinstance(force, bool):
+        return force
+    else:
+        for f in force:
+            if '*' in f or '?' in f:
+                if fnmatch(path, f):
+                    return True
+            elif name == f:
+                return True
+    return False
 
 def read_markdown(filename):
     """Reads markdown file, converts output and fetches title and meta-data for

--- a/src/sigal/utils.py
+++ b/src/sigal/utils.py
@@ -23,6 +23,7 @@ import os
 import shutil
 from functools import lru_cache
 from urllib.parse import quote
+from fnmatch import fnmatch
 
 from markdown import Markdown
 from markupsafe import Markup

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,16 @@ def test_copy(tmpdir):
     utils.copy(src, dst)
     utils.copy(src, dst)
 
+def test_force(tmpdir):
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', False) is False
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', True) is True
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*']) is True
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*Pics']) is True
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures/*']) is False
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['New Pics']) is True
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures']) is False
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Something']) is False
+    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Gallery', '*Pics']) is True
 
 def test_check_or_create_dir(tmpdir):
     path = str(tmpdir.join("new_directory"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,15 +44,15 @@ def test_copy(tmpdir):
     utils.copy(src, dst)
 
 def test_force(tmpdir):
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', False) is False
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', True) is True
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*']) is True
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*Pics']) is True
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures/*']) is False
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['New Pics']) is True
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures']) is False
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Something']) is False
-    assert should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Gallery', '*Pics']) is True
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', False) is False
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', True) is True
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*']) is True
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Gallery/*Pics']) is True
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures/*']) is False
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['New Pics']) is True
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures']) is False
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Something']) is False
+    assert utils.should_reprocess_album('Gallery/New Pics', 'New Pics', ['Pictures', 'Gallery', '*Pics']) is True
 
 def test_check_or_create_dir(tmpdir):
     path = str(tmpdir.join("new_directory"))


### PR DESCRIPTION
Like --force, but can specify multiple specific album names or wildcard patterns to apply to entire album paths like:
-a Pics/*
-a *Wedding*
-a 'Landscape Photos'