### PR TITLE
Fix issue with tox-gh-actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Tox
       run: python -m pip install tox tox-gh-actions coverage
     - name: Run Tox
-      run: tox
+      run: tox run
     - name: Convert coverage
       run: python -m coverage xml
     - name: Upload coverage to Codecov


### PR DESCRIPTION
py310-pillow-latest: tox-gh-actions couldn't understand the parallel
option. ignoring the given option: 0