### PR TITLE
Avoid IndexError with empty source dir

### DIFF
--- a/src/sigal/__main__.py
+++ b/src/sigal/__main__.py
@@ -207,7 +207,7 @@ def build(
         opt = " ({})".format(", ".join(opt)) if opt else ""
         return f"{stats[_type]} {_type}s{opt}"
 
-    if not quiet:
+    if not quiet and len(stats) > 0:
         stats_str = ""
         types = sorted({t.rsplit("_", 1)[0] for t in stats})
         for t in types[:-1]:


### PR DESCRIPTION
When running with an empty source directory, sigal would crash with the following error:
```
$ touch empty.py
$ mkdir emptydir
$ sigal build -c empty.py  emptydir/
Collecting albums, done.
  Sorting albums  [####################################]  100%
   Sorting media  [####################################]  100%
WARNING: No albums found.
Traceback (most recent call last):
  File "/home/jean/ws/src/sigal/env/bin/sigal", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/jean/ws/src/sigal/env/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jean/ws/src/sigal/env/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/jean/ws/src/sigal/env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jean/ws/src/sigal/env/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jean/ws/src/sigal/env/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jean/ws/src/sigal/src/sigal/__main__.py", line 215, in build
    stats_str += f"{format_stats(types[-1])}"
                                 ~~~~~^^^^
IndexError: list index out of range
```

This PR avoids printing stats when none have been gathered.