### PR TITLE
Add data files for themes and plugins using setuptools package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ license-files = ["LICENSE"]
 where = ["src"]
 namespaces = true
 
+[tool.setuptools.package-data]
+sigal = [
+    "plugins/encrypt/static/*",
+    "themes/**",
+]
+
 [tool.setuptools_scm]
 write_to = "src/sigal/version.py"
 


### PR DESCRIPTION
Use setuptools' `package-data` [1] to unconditionally add all files
below sigal's `themes/` dir and all data files below the
`plugins/encrypt/static/` dir to a wheel.
This works without any SCM integration and without `MANIFEST.in`.

Fixes https://github.com/saimn/sigal/issues/500

[1] https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data