### PR TITLE
Cache input_size to make updating faster

### DIFF
--- a/src/sigal/plugins/extended_caching.py
+++ b/src/sigal/plugins/extended_caching.py
@@ -78,6 +78,8 @@ def load_metadata(album):
                 media.file_metadata = data["file_metadata"]
             if "exif" in data:
                 media.exif = data["exif"]
+            if "input_size" in data:
+                media.input_size = data["input_size"]
 
             try:
                 mod_date = int(get_mod_date(media.markdown_metadata_filepath))
@@ -134,6 +136,8 @@ def save_cache(gallery):
                 data["file_metadata"] = media.file_metadata
                 if hasattr(media, "exif"):
                     data["exif"] = media.exif
+                if hasattr(media, "input_size"):
+                    data["input_size"] = media.input_size
 
             try:
                 meta_mod_date = int(get_mod_date(media.markdown_metadata_filepath))


### PR DESCRIPTION
By adding caching for `input_size`, image files that have previously been processed do not need to be opened at all when a gallery is updated.  This improves update speed significantly, especially on slower systems with many image files.  I've seen anywhere from a 1.5x to 10x improvement with ~50k images when testing this PR on various systems.