### PR TITLE
Allow sorting by negative numbers

### DIFF
--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -530,11 +530,11 @@ class Album:
             elif medias_sort_attr.startswith("meta."):
                 meta_key = medias_sort_attr.split(".", 1)[1]
                 key = natsort_keygen(
-                    key=lambda s: s.meta.get(meta_key, [""])[0], alg=ns.LOCALE
+                    key=lambda s: s.meta.get(meta_key, [""])[0], alg=ns.SIGNED|ns.LOCALE
                 )
             else:
                 key = natsort_keygen(
-                    key=lambda s: getattr(s, medias_sort_attr), alg=ns.LOCALE
+                    key=lambda s: getattr(s, medias_sort_attr), alg=ns.SIGNED|ns.LOCALE
                 )
 
             self.medias.sort(key=key, reverse=self.settings["medias_sort_reverse"])

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -515,7 +515,7 @@ class Album:
                         continue
                 return ""
 
-            key = natsort_keygen(key=sort_key, alg=ns.LOCALE)
+            key = natsort_keygen(key=sort_key, alg=ns.SIGNED|ns.LOCALE)
             self.subdirs.sort(key=key, reverse=reverse)
 
         signals.albums_sorted.send(self)

--- a/tests/sample/pictures/dir1/test2/21.md
+++ b/tests/sample/pictures/dir1/test2/21.md
@@ -1,4 +1,4 @@
 Title: in"title"
-Order: 01
+Order: -10
 
 in"description

--- a/tests/sample/pictures/dir1/test2/index.md
+++ b/tests/sample/pictures/dir1/test2/index.md
@@ -1,1 +1,2 @@
-Order: 01
+Order: -10
+PartialOrder: 01

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -234,8 +234,7 @@ def test_albums_sort(settings):
     a.sort_subdirs("title")
     assert [im.title for im in a.albums] == list(reversed(titles))
 
-    orders = ["01", "02", "03"]
-    orders.sort()
+    orders = ["-10", "02", "03"]
     settings["albums_sort_reverse"] = False
     a = Album("dir1", settings, album["subdirs"], album["medias"], gal)
     a.sort_subdirs("meta.order")


### PR DESCRIPTION
One of my users noticed that negative numbers specified in meta ordering weren't being sorted correctly.  This adds `ns.SIGNED` to the sorting, as well as modifying the tests to show it works.