### PR TITLE
Clarify default value of keep_orig in config comments

### DIFF
--- a/src/sigal/templates/sigal.conf.py
+++ b/src/sigal/templates/sigal.conf.py
@@ -128,7 +128,7 @@ thumb_size = (280, 210)
 # thumb_video_black_max_colors = 4
 
 # Keep original image (default: False)
-# keep_orig = True
+# keep_orig = False
 
 # Subdirectory for original images
 # orig_dir = 'original'


### PR DESCRIPTION
This pull request clarifies the default value of `keep_orig` in the configuration comments. It changes the comment to explicitly state that the default is `False`, ensuring clear understanding for new users.