### PR TITLE
Update only a single album

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -72,6 +72,17 @@ Optional arguments:
             My Pictures/Landscapes => Force
             My Other Pictures/Landscapes => Force
 
+``--only-album``
+  Only write a specific album path. Other albums will be ignored as if you
+  had set the ``ignore_directories`` setting to all of their names.
+
+::
+
+    --only-album 'My Pictures/Pics'
+            My Pictures/Pics   => Write
+            My Pictures/Pics/* => Ignore
+            *                  => Ignore
+
 ``-v, --verbose``
   Show all messages
 

--- a/src/sigal/__main__.py
+++ b/src/sigal/__main__.py
@@ -85,6 +85,15 @@ def init(path):
         "the album name. (-a 'My Pictures/* Pics' -a 'Festival')"
     ),
 )
+@option(
+    "--only-album",
+    default=None,
+    help=(
+        "Only write a specific album path. Other albums will be ignored "
+        "as if you had set the `ignore_directories` setting to all of "
+        "their names. (--only-album 'My Pictures/Pics')"
+    ),
+)
 @option("-v", "--verbose", is_flag=True, help="Show all messages")
 @option(
     "-d",
@@ -120,6 +129,7 @@ def build(
     quiet,
     force,
     force_album,
+    only_album,
     config,
     theme,
     title,
@@ -186,7 +196,7 @@ def build(
     locale.setlocale(locale.LC_ALL, settings["locale"])
     init_plugins(settings)
 
-    gal = Gallery(settings, ncpu=ncpu, show_progress=show_progress)
+    gal = Gallery(settings, ncpu=ncpu, show_progress=show_progress, only_album=only_album)
     gal.build(force=force_album if len(force_album) else force)
 
     # copy extra files

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -699,7 +699,7 @@ class Album:
 
 
 class Gallery:
-    def __init__(self, settings, ncpu=None, show_progress=False):
+    def __init__(self, settings, ncpu=None, show_progress=False, only_album=None):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
         self.stats = defaultdict(int)
@@ -711,6 +711,7 @@ class Gallery:
 
         # Build the list of directories with images
         albums = self.albums = {}
+        self.only_album = only_album
         src_path = self.settings["source"]
 
         ignore_dirs = settings["ignore_directories"]
@@ -724,17 +725,26 @@ class Gallery:
 
         self.progressbar_target = None if show_progress and isatty else Devnull()
 
-        for path, dirs, files in os.walk(src_path, followlinks=True, topdown=False):
+        for path, dirs, files in os.walk(src_path, followlinks=True, topdown=True):
             if show_progress:
                 print("\rCollecting albums " + next(progressChars), end="")
             relpath = os.path.relpath(path, src_path)
 
-            # Test if the directory match the ignore_dirs settings
-            if ignore_dirs and any(
-                fnmatch.fnmatch(relpath, ignore) for ignore in ignore_dirs
-            ):
-                self.logger.info("Ignoring %s", relpath)
-                continue
+            for d in dirs[:]:
+                dir_relpath = join(relpath, d) if relpath != "." else d
+
+                # Test if the directory matches the only_album settings
+                if only_album and dir_relpath not in only_album and relpath != only_album:
+                    self.logger.info("Skipping %s", dir_relpath)
+                    dirs.remove(d)
+                    continue
+
+                # Test if the directory matches the ignore_dirs settings
+                if ignore_dirs and any(
+                    fnmatch.fnmatch(dir_relpath, ignore) for ignore in ignore_dirs
+                ):
+                    self.logger.info("Ignoring %s", dir_relpath)
+                    dirs.remove(d)
 
             # Remove files that match the ignore_files settings
             if ignore_files:
@@ -746,21 +756,29 @@ class Gallery:
                 files = [os.path.split(f)[1] for f in files_path]
                 self.logger.debug("Files after filtering: %r", files)
 
-            # Remove sub-directories that have been ignored in a previous
-            # iteration (as topdown=False, sub-directories are processed before
-            # their parent
-            for d in dirs[:]:
-                path = join(relpath, d) if relpath != "." else d
-                if path not in albums.keys():
-                    dirs.remove(d)
-
             album = Album(relpath, settings, dirs, files, self)
 
-            if not album.medias and not album.albums:
-                self.logger.info("Skip empty album: %r", album)
-            else:
-                album.create_output_directories()
-                albums[relpath] = album
+            self.logger.debug("Processing subdirs: %r", dirs)
+
+            self.stats["album"] += 1
+            albums[relpath] = album
+
+        # Remove empty albums
+        for relpath in sorted(albums.keys(), key=lambda x: len(x), reverse=True):
+            album = albums[relpath]
+            keep_only_album_children = only_album and os.path.relpath(os.path.dirname(album.src_path), src_path) == only_album
+            if not album.medias and not album.subdirs and not keep_only_album_children:
+                self.logger.info("Skip empty album: %r", album.path)
+                del albums[relpath]
+                if relpath != '.':
+                    super_album = os.path.relpath(os.path.dirname(album.src_path), src_path)
+                    self.logger.debug("Deleting album from super album %s", super_album)
+                    albums[super_album].subdirs.remove(os.path.basename(album.path))
+                self.stats["album_skipped"] += 1
+        self.stats["album"] -= self.stats["album_skipped"]
+
+        for album in albums.values():
+            album.create_output_directories()
 
         if show_progress:
             print("\rCollecting albums, done.")
@@ -771,6 +789,8 @@ class Gallery:
             file=self.progressbar_target,
         ) as progress_albums:
             for album in progress_albums:
+                if only_album and album.path != only_album:
+                    continue
                 album.sort_subdirs(settings["albums_sort_attr"])
 
         with progressbar(
@@ -779,6 +799,8 @@ class Gallery:
             file=self.progressbar_target,
         ) as progress_albums:
             for album in progress_albums:
+                if only_album and album.path != only_album:
+                    continue
                 album.sort_medias(settings["medias_sort_attr"])
 
         self.logger.debug("Albums:\n%r", albums.values())
@@ -846,9 +868,11 @@ class Gallery:
                 show_eta=False,
                 file=self.progressbar_target,
             ) as albums:
-                media_list = [
-                    f for album in albums for f in self.process_dir(album, force=force)
-                ]
+                media_list = []
+                for album in albums:
+                    if self.only_album and album.path != self.only_album:
+                        continue
+                    media_list.extend(self.process_dir(album, force=force))
         except KeyboardInterrupt:
             sys.exit("Interrupted")
 
@@ -902,6 +926,8 @@ class Gallery:
                 file=self.progressbar_target,
             ) as albums:
                 for album in albums:
+                    if self.only_album and album.path != self.only_album:
+                        continue
                     if album.albums:
                         if album.medias:
                             self.logger.warning(

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -326,6 +326,21 @@ def test_gallery(settings, tmp_path, caplog):
         logger.setLevel(logging.INFO)
 
 
+def test_gallery_only_album(settings, tmp_path, caplog):
+    "Test the Gallery class updating a single album."
+
+    caplog.set_level("ERROR")
+    settings["destination"] = str(tmp_path)
+    gal = Gallery(settings, ncpu=1, only_album="dir1")
+    gal.build()
+
+    out_html = os.path.join(settings["destination"], "dir1", "index.html")
+    assert os.path.isfile(out_html)
+
+    out_html2 = os.path.join(settings["destination"], "dir2", "index.html")
+    assert not os.path.isfile(out_html2)
+
+
 def test_custom_theme(settings, tmp_path, caplog):
     theme_path = tmp_path / "mytheme"
     tpl_path = theme_path / "templates"


### PR DESCRIPTION
Following up on #508, this PR adds a cli flag for updating a single album.

One key difference compared to the `ignore_directories` setting is that this will add any albums necessary to create the breadcrumbs in the selected album, but not write them.

Note that I had to adjust how the album source tree is walked to top-down mode, so it wouldn't walk the whole tree if it didn't need to.  This meant changing how to ignore albums, including editing the nomedia plugin.

I also added a count of the albums processed to the stats, as that helped with debugging.  I can remove that if necessary.