### PR TITLE
sigal serve --browser : open in your default browser

### DIFF
--- a/src/sigal/__main__.py
+++ b/src/sigal/__main__.py
@@ -25,6 +25,7 @@ import pathlib
 import socketserver
 import sys
 import time
+import webbrowser
 from http import server
 
 import click
@@ -227,7 +228,8 @@ def build(
     show_default=True,
     help="Configuration file",
 )
-def serve(destination, port, config):
+@option("-b", "--browser", is_flag=True, help="Open in your default browser")
+def serve(destination, port, config, browser):
     """Run a simple web server."""
     if os.path.exists(destination):
         pass
@@ -252,6 +254,9 @@ def serve(destination, port, config):
     Handler = server.SimpleHTTPRequestHandler
     httpd = socketserver.TCPServer(("", port), Handler, False)
     print(f" * Running on http://127.0.0.1:{port}/")
+
+    if browser:
+        webbrowser.open(f"http://127.0.0.1:{port}/")
 
     try:
         httpd.allow_reuse_address = True


### PR DESCRIPTION
Hi!

First, thank you very much for maintaining this tool.
Thanks yo you, yesterday I was able to very quickly setup a web gallery that perfectly suited my need.

This very short contribution introduces a hand `--browser` / `-b` flag to the `sigal serve` command, that opens the sigal gallery in the user default web brower, using the standard Python module [webbrowser](https://docs.python.org/3/library/webbrowser.html).

I did not add a unit test to `tests/test_cli.py`, because it seemed difficult to me to test the standard behaviour of the `webbrowser` stanbdard package.
If need be, I can add one that ensure that `webbrowser.open()` gets called, using a mock.