### PR TITLE
Added support for display_timestamp setting

### DIFF
--- a/src/sigal/settings.py
+++ b/src/sigal/settings.py
@@ -33,6 +33,7 @@ _DEFAULT_CONFIG = {
     "colorbox_column_size": 3,
     "copy_exif_data": False,
     "datetime_format": "%c",
+    "display_timestamp": False,
     "destination": "_build",
     "files_to_copy": (),
     "galleria_theme": "classic",

--- a/src/sigal/templates/sigal.conf.py
+++ b/src/sigal/templates/sigal.conf.py
@@ -86,6 +86,9 @@ img_size = (800, 600)
 # https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
 # datetime_format = '%c'
 
+# Display generated datetime in the resulting output
+# display_timestamp = False
+
 # Jpeg options
 # jpg_options = {'quality': 85,
 #                'optimize': True,

--- a/src/sigal/themes/default/templates/footer.html
+++ b/src/sigal/themes/default/templates/footer.html
@@ -12,5 +12,8 @@
         <span><a href={{ settings.atom_feed.feed_url }}>Atom Feed</a></span>
       {% endif %}
     {% endif %}
+    {% if settings.display_timestamp %}
+        @ {{ generated_timestamp }}
+    {% endif %}
   </p>
 </footer>

--- a/src/sigal/writer.py
+++ b/src/sigal/writer.py
@@ -27,6 +27,7 @@ import shutil
 import stat
 import sys
 import types
+from datetime import datetime
 
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
 from jinja2.exceptions import TemplateNotFound
@@ -138,6 +139,7 @@ class AbstractWriter:
             "index_title": self.index_title,
             "settings": self.settings,
             "sigal_link": sigal_link,
+            "generated_timestamp": datetime.now().strftime(self.settings['datetime_format']),
             "theme": {
                 "name": os.path.basename(self.theme),
                 "url": url_from_path(os.path.relpath(self.theme_path, album.dst_path)),


### PR DESCRIPTION
Shows the generation timestamp in the resulting galleries and albums

This is helpful for automated/cron updates to see when the last run was