### PR TITLE
Localize images from Markdown metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ alphabetical order):
 - Sébastien Maccagnoni-Munch
 - Sean Grider (@kaibutsux)
 - Simon Conseil
+- @stasinos
 - Stefano Zacchiroli
 - @subwarpspeed
 - @t-animal

--- a/docs/image_information.rst
+++ b/docs/image_information.rst
@@ -16,6 +16,10 @@ keys are used by Sigal to get the useful informations on the gallery:
 - *Title*: the image title.
 - *Date*: the file date, useful when it cannot be read from the EXIF metadata,
   e.g. for videos and some image formats.
+- *Lat* and *Lon*: geo-location for positioning the image on map galleries.
+  Note that this overrides EXIF coordinates, so except for localizing when
+  EXIF cooredinates are missing it can also be used to localize the image
+  based on what is depicted instead of where the camera was standing.
 
 Any additional meta-data is available in the templates. For instance::
 

--- a/docs/image_information.rst
+++ b/docs/image_information.rst
@@ -18,7 +18,7 @@ keys are used by Sigal to get the useful informations on the gallery:
   e.g. for videos and some image formats.
 - *Lat* and *Lon*: geo-location for positioning the image on map galleries.
   Note that this overrides EXIF coordinates, so except for localizing when
-  EXIF cooredinates are missing it can also be used to localize the image
+  EXIF coordinates are missing it can also be used to localize the image
   based on what is depicted instead of where the camera was standing.
 
 Any additional meta-data is available in the templates. For instance::

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2017      - Mate Lakat
 # Copyright (c) 2018      - Edwin Steele
 # Copyright (c) 2021      - Tim AtLee
+# Copyright (c) 2024      - Stasinos Konstantopoulos
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -217,7 +218,7 @@ class Media:
 
     def _get_markdown_metadata(self):
         """Get metadata from filename.md."""
-        meta = {"title": "", "description": "", "meta": {}}
+        meta = {"title": "", "description": "", "lat": "", "lon": "", "meta": {}}
         if isfile(self.markdown_metadata_filepath):
             meta.update(read_markdown(self.markdown_metadata_filepath))
         return meta
@@ -285,6 +286,15 @@ class Image(Media):
             meta["description"] = self.file_metadata["iptc"].get("description", "")
 
         return meta
+
+    @cached_property
+    def lat(self):
+        return self.markdown_metadata.get("lat", {})
+
+    @cached_property
+    def lon(self):
+        """Other metadata extracted from the Markdown index.md file."""
+        return self.markdown_metadata.get("lon", {})
 
     @cached_property
     def raw_exif(self):

--- a/src/sigal/gallery.py
+++ b/src/sigal/gallery.py
@@ -289,12 +289,13 @@ class Image(Media):
 
     @cached_property
     def lat(self):
-        return self.markdown_metadata.get("lat", {})
+        """If not `None`, latitude extracted from the Markdown index.md file."""
+        return self.markdown_metadata.get("lat")
 
     @cached_property
     def lon(self):
-        """Other metadata extracted from the Markdown index.md file."""
-        return self.markdown_metadata.get("lon", {})
+        """If not `None`, longitude extracted from the Markdown index.md file."""
+        return self.markdown_metadata.get("lon")
 
     @cached_property
     def raw_exif(self):

--- a/src/sigal/themes/default/templates/map.html
+++ b/src/sigal/themes/default/templates/map.html
@@ -19,7 +19,15 @@
 
   var photos = [];
   {% for media in album.medias %}
-    {% if media.exif and media.exif.gps %}
+    {% if media.lat and media.lon %}
+    photos.push({
+      lat: {{ media.lat }},
+      lng: {{ media.lon }},
+      url: "{{ media.thumbnail }}",
+      caption: "{{ media.title }}",
+      thumbnail: "{{ media.thumbnail }}",
+    });
+    {% elif media.exif and media.exif.gps %}
     photos.push({
       lat: {{ media.exif.gps.lat }},
       lng: {{ media.exif.gps.lon }},

--- a/src/sigal/utils.py
+++ b/src/sigal/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2011-2023 - Simon Conseil
+# Copyright (c) 2024 - Stasinos Konstantopoulos
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -138,6 +139,14 @@ def read_markdown(filename):
         output["meta"] = meta
         try:
             output["title"] = MD.Meta["title"][0]
+        except KeyError:
+            pass
+        try:
+            output["lat"] = MD.Meta["lat"][0]
+        except KeyError:
+            pass
+        try:
+            output["lon"] = MD.Meta["lon"][0]
         except KeyError:
             pass
 

--- a/src/sigal/utils.py
+++ b/src/sigal/utils.py
@@ -137,18 +137,12 @@ def read_markdown(filename):
         pass
     else:
         output["meta"] = meta
-        try:
-            output["title"] = MD.Meta["title"][0]
-        except KeyError:
-            pass
-        try:
-            output["lat"] = MD.Meta["lat"][0]
-        except KeyError:
-            pass
-        try:
-            output["lon"] = MD.Meta["lon"][0]
-        except KeyError:
-            pass
+        l = MD.Meta.get("title", [])
+        if l: output["title"] = l[0]
+        l = MD.Meta.get("lat", [])
+        if l: output["lat"] = l[0]
+        l = MD.Meta.get("lon", [])
+        if l: output["lon"] = l[0]
 
     return output
 


### PR DESCRIPTION
Read Lat, Lon fields in the Markdown files to localize images. These override the EXIF GPS coordinates, if both are present, allowing manually localizing the images on the map. This is useful to, for instance, localize the image based on what is depicted instead of where the camera was standing.