### PR TITLE
Security: Stored XSS via unsanitized album/media HTML content in templates

### DIFF
--- a/src/sigal/themes/default/templates/description.html
+++ b/src/sigal/themes/default/templates/description.html
@@ -3,7 +3,7 @@
     <a href='{{ media.big_url }}'>Full size</a>
   {%- endif -%}
   {%- if media.description -%}
-    <br>{{ media.description }}
+    <br>{{ media.description|e }}
   {%- endif -%}
   {%- if media.exif -%}
     <div class='film-meta'>


### PR DESCRIPTION
## Problem

Multiple templates render `album.description` and `media.description` directly into HTML. If these fields come from untrusted markdown/metadata (which can contain raw HTML), attacker-controlled script can be persisted into generated pages and execute in visitors' browsers.

**Severity**: `high`
**File**: `src/sigal/themes/default/templates/description.html`

## Solution

Sanitize descriptions before rendering (e.g., bleach/allowlist sanitizer) and/or explicitly escape output in templates. If rich HTML is required, only allow a strict safe tag/attribute subset.

## Changes

- `src/sigal/themes/default/templates/description.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
