### PR TITLE
Security: Sensitive encryption password embedded in client-side HTML

### DIFF
--- a/src/sigal/themes/default/templates/decrypt.html
+++ b/src/sigal/themes/default/templates/decrypt.html
@@ -2,7 +2,6 @@
 <script src="{{ theme.url }}/decrypt.js"></script>
 <script>
     Decryptor.init({
-        password: "{{ encrypt_options.filtered_password }}",
         sw_script: "{{ theme.url }}/../sw.js",
         galleryId: "{{ encrypt_options.galleryId }}",
         gcm_tag: "{{ encrypt_options.escaped_gcm_tag }}",


### PR DESCRIPTION
## Problem

The encrypt plugin injects `encrypt_options.filtered_password` directly into JavaScript initialization. When `ask_password` is false, the decryption secret is effectively published to every client, defeating confidentiality against anyone who can view page source.

**Severity**: `high`
**File**: `src/sigal/themes/default/templates/decrypt.html`

## Solution

Do not embed decryption passwords in generated HTML. Require interactive password entry (`ask_password=True`) and derive keys client-side from user input only. Document that static-site encryption cannot protect against source disclosure when keys are shipped to browsers.

## Changes

- `src/sigal/themes/default/templates/decrypt.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
